### PR TITLE
Fix: Add "OK" and "Cancel" to translation #214 [wip]

### DIFF
--- a/res/layout/ok_cancel.xml
+++ b/res/layout/ok_cancel.xml
@@ -23,7 +23,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:maxLines="1"
-            android:text="@android:string/cancel" />
+            android:text="@string/cancel" />
 
         <Button
             android:id="@+id/okButton"
@@ -32,7 +32,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:maxLines="1"
-            android:text="@android:string/ok" />
+            android:text="@string/ok" />
     </LinearLayout>
 
 </LinearLayout>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -284,4 +284,6 @@ es welche gibt) anzeigen lassen.</string>
   <string name="catalan">Katalanisch</string>
   <string name="polish">Polnisch</string>
   <string name="tamil">Tamil</string>
+  <string name="cancel">Abbrechen</string>
+  <string name="ok">Ok</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -96,6 +96,12 @@ there are any).</string>
     <string name="current_date_set">Date was set to current.</string>
     <string name="added_1h">1 hour was added.</string>
 
+    <string name="ok">OK</string>
+    <string name="cancel">Cancel</string>
+
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    
     <string name="pref_transport_network">Transport Network</string>
     <string name="pref_hide_departure_time">Hide departure time</string>
     <string name="pref_hide_departure_time_summary">Only show arrival time when displaying intermediate stops</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -31,6 +31,7 @@
             android:entryValues="@array/pref_optimize_values"
             android:defaultValue="@string/pref_optimize_value_default"
             android:summary="%s"
+            android:negativeButtonText="@string/cancel"
             />
 
         <ListPreference
@@ -40,6 +41,7 @@
             android:entryValues="@array/pref_walk_speed_values"
             android:defaultValue="@string/pref_walk_speed_value_default"
             android:summary="%s"
+            android:negativeButtonText="@string/cancel"
             />
 
     </PreferenceCategory>
@@ -55,6 +57,7 @@
             android:entryValues="@array/pref_theme_values"
             android:defaultValue="@string/pref_theme_value_light"
             android:summary="%s"
+            android:negativeButtonText="@string/cancel"
             />
 
         <ListPreference
@@ -64,6 +67,7 @@
             android:entryValues="@array/pref_language_values"
             android:defaultValue="@string/pref_language_value_default"
             android:summary="%s"
+            android:negativeButtonText="@string/cancel"
             />
 
         <CheckBoxPreference

--- a/src/de/grobox/liberario/fragments/RecentTripsFragment.java
+++ b/src/de/grobox/liberario/fragments/RecentTripsFragment.java
@@ -301,18 +301,18 @@ public class RecentTripsFragment extends TransportrListFragment {
 				case R.id.action_trip_delete:
 					new AlertDialog.Builder(getActivity())
 					.setMessage(getActivity().getResources().getString(R.string.clear_recent_trips, getListView().getCheckedItemCount()))
-					.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+					.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 						public void onClick(DialogInterface dialog, int id) {
 							if(isFavouriteSelected()) {
 								new AlertDialog.Builder(getActivity())
 								.setMessage(R.string.removing_from_favourites)
-								.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+								.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
 									public void onClick(DialogInterface dialog, int id) {
 										deleteSelected();
 										mode.finish();
 									}
 								})
-										.setNegativeButton(android.R.string.cancel, null)
+										.setNegativeButton(R.string.cancel, null)
 								.show();
 							} else {
 								deleteSelected();
@@ -320,7 +320,7 @@ public class RecentTripsFragment extends TransportrListFragment {
 							}
 						}
 					})
-					.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
+					.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 						public void onClick(DialogInterface dialog, int id) {
 							dialog.cancel();
 						}

--- a/src/de/grobox/liberario/ui/TimeAndDateView.java
+++ b/src/de/grobox/liberario/ui/TimeAndDateView.java
@@ -21,6 +21,7 @@ import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
+	import android.content.DialogInterface;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -229,9 +230,11 @@ public class TimeAndDateView extends LinearLayout {
 		public Dialog onCreateDialog(Bundle savedInstanceState) {
 			int hour = calendar.get(Calendar.HOUR_OF_DAY);
 			int minute = calendar.get(Calendar.MINUTE);
-
-			return new TimePickerDialog(getActivity(), this, hour, minute,
+			TimePickerDialog tpd = new TimePickerDialog(getActivity(), this, hour, minute,
 					android.text.format.DateFormat.is24HourFormat(getActivity()));
+			tpd.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.cancel), tpd);
+			tpd.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.ok), tpd);
+			return tpd;
 		}
 
 		public void onTimeSet(TimePicker view, int hourOfDay, int minute) {
@@ -250,8 +253,10 @@ public class TimeAndDateView extends LinearLayout {
 			int year = calendar.get(Calendar.YEAR);
 			int month = calendar.get(Calendar.MONTH);
 			int day = calendar.get(Calendar.DAY_OF_MONTH);
-
-			return new DatePickerDialog(getActivity(), this, year, month, day);
+			DatePickerDialog dpd = new DatePickerDialog(getActivity(), this, year, month, day);
+			dpd.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.cancel), dpd);
+			dpd.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.ok), dpd);
+			return dpd;
 		}
 
 		public void onDateSet(DatePicker view, int year, int month, int day) {


### PR DESCRIPTION
Datepicker and some other fragments still don't use translatable button strings.