### PR TITLE
add support for fr-nw (North-West of France)

### DIFF
--- a/art/networks/network_francenorthwest_logo.svg
+++ b/art/networks/network_francenorthwest_logo.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   height="64"
+   width="64"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="network_francenorthwest_logo.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1362"
+     inkscape:window-height="714"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="50.315171"
+     inkscape:cy="18.98017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <path
+     id="rect4"
+     d="m 42.66,0 21.34,0 L 64,64 l -21.34,0 z"
+     style="fill:#ed2939" />
+  <path
+     id="rect6"
+     d="m 21.33,0 21.33,0 L 42.66,64 21.33,64 Z"
+     style="fill:#ffffff" />
+  <path
+     id="rect8"
+     d="m 0,0 21.33,0 0,64 -21.33,0 z"
+     style="fill:#002395" />
+  <circle
+     style="fill:#ffb300;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path3487-3-3"
+     cx="47.903"
+     cy="48.123001"
+     r="13"
+     sodipodi:cx="47.903"
+     sodipodi:cy="48.123001"
+     sodipodi:rx="13"
+     sodipodi:ry="13"
+     transform="matrix(-1,0,0,1,95.832212,0)" />
+  <path
+     style="fill:#654700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 47.903,35.117858 0,13 -13,0 a 13,13 0 0 1 13,-13 z"
+     id="path3487-6"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/res/drawable/network_francenorthwest_logo.xml
+++ b/res/drawable/network_francenorthwest_logo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+
+    <path
+        android:fillColor="#ed2939"
+        android:pathData="M42.66,0 L64,0 L64,64 L42.66,64 Z" />
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M21.33,0 L42.66,0 L42.66,64 L21.33,64 Z" />
+    <path
+        android:fillColor="#002395"
+        android:pathData="M0,0 L21.33,0 L21.33,64 L0,64 Z" />
+    <path
+        android:fillColor="#ffb300"
+        android:strokeWidth="1"
+        android:pathData="M47.9292,35.123 C40.7495,35.123,34.9292,40.9433,34.9292,48.123
+C34.9292,55.3027,40.7495,61.123,47.9292,61.123
+C55.1089,61.123,60.9292,55.3027,60.9292,48.123
+C60.9292,40.9433,55.1089,35.123,47.9292,35.123 Z" />
+    <path
+        android:fillColor="#654700"
+        android:strokeWidth="1"
+        android:pathData="M47.903,35.1179 L47.903,48.1179 L34.903,48.1179 A13,13,0,0,1,47.903,35.1179 Z" />
+</vector>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -285,6 +285,8 @@ there are any).</string>
     <string name="np_desc_frenchsouthwest_networks" translatable="false">SNCF, TransGironde, TBC, Tisséo</string>
     <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>
     <string name="np_desc_francenortheast_networks" translatable="false">SNCF, CTS, Transpole, STAN, LE MET</string>
+    <string name="np_desc_francenorthwest">Bretagne, Pays de la Loire, Centre, Basse Normandie, Haute Normandie</string>
+    <string name="np_desc_francenorthwest_networks" translatable="false">LILA, Star, TAN, IRIGO, SNCF</string>
     <string name="np_desc_it">Roma, Milano, Torino, Venezia, Palermo, Trento</string>
     <string name="np_desc_it_networks" translatable="false">ATM, GTT, AMAT, ACTV</string>
     <string name="np_desc_ontario">Ottawa, Toronto</string>
@@ -302,6 +304,7 @@ there are any).</string>
     <string name="np_name_br_floripa">Florianópolis</string>
     <string name="np_name_frenchsouthwest">France South West</string>
     <string name="np_name_francenortheast">France North East</string>
+    <string name="np_name_francenorthwest">France North West</string>
     <string name="np_name_ontario">Ontario</string>
     <string name="np_name_quebec">Quebec</string>
     <string name="np_name_rtachicago">Chicago</string>

--- a/src/de/grobox/liberario/NetworkProviderFactory.java
+++ b/src/de/grobox/liberario/NetworkProviderFactory.java
@@ -96,6 +96,7 @@ public final class NetworkProviderFactory
 	private static Reference<ItalyProvider> italyProviderRef;
 	private static Reference<FrenchSouthWestProvider> frenchSouthWestProviderRef;
 	private static Reference<FranceNorthEastProvider> franceNorthEastProviderRef;
+	private static Reference<FranceNorthWestProvider> franceNorthWestProviderRef;
 	private static Reference<OntarioProvider> ontarioProviderRef;
 	private static Reference<QuebecProvider> quebecProviderRef;
 	private static Reference<RtaChicagoProvider> rtaChicagoProviderRef;
@@ -1002,6 +1003,19 @@ public final class NetworkProviderFactory
 
 			final FranceNorthEastProvider provider = new FranceNorthEastProvider(NAVITIA);
 			franceNorthEastProviderRef = new SoftReference<>(provider);
+			return provider;
+		}
+		else if (networkId.equals(NetworkId.FRANCENORTHWEST))
+		{
+			if (franceNorthWestProviderRef != null)
+			{
+				final FranceNorthWestProvider provider = franceNorthWestProviderRef.get();
+				if(provider != null)
+					return provider;
+			}
+
+			final FranceNorthWestProvider provider = new FranceNorthWestProvider(NAVITIA);
+			franceNorthWestProviderRef = new SoftReference<>(provider);
 			return provider;
 		}
 		else if (networkId.equals(NetworkId.ONTARIO))

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -476,6 +476,13 @@ public class TransportNetworks {
 				.setGoodLineNames(true)
 		);
 
+		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHWEST)
+				.setName(getString(R.string.np_name_francenorthwest))
+				.setDescription(getString(R.string.np_desc_francenorthwest) + "\n(" + getString(R.string.np_desc_francenorthwest_networks) + ")")
+				.setRegion(region)
+				.setStatus(ALPHA)
+		);
+
 		// New Zealand
 
 		list.add(new TransportNetwork(context, NetworkId.NZ)


### PR DESCRIPTION
This PR adds a network logo (modified version of the existing logos) and the integration of fr-nw from navitia.
Moreover I bumped the version of PTE.
Unfortunately, somewhere in the process several LINT-errors were introduced. I don't have a complete Android development environment at the moment and am lacking the knowledge for debugging this.

Please let me know if and how I can help getting this ready. Apart from that feel free to edit this PR (since GitHub seems to have added that feature).