### PR TITLE
Improve network provider list

### DIFF
--- a/res/drawable-xhdpi/.directory
+++ b/res/drawable-xhdpi/.directory
@@ -1,6 +1,0 @@
-[Dolphin]
-HeaderColumnWidths=270,74,108
-SortRole=date
-Timestamp=2016,9,30,23,17,15
-Version=3
-ViewMode=1

--- a/res/drawable-xhdpi/.directory
+++ b/res/drawable-xhdpi/.directory
@@ -1,0 +1,6 @@
+[Dolphin]
+HeaderColumnWidths=270,74,108
+SortRole=date
+Timestamp=2016,9,30,23,17,15
+Version=3
+ViewMode=1

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -204,7 +204,7 @@ there are any).</string>
     <string name="np_desc_wien">Vienna</string>
 
     <string name="np_region_belgium">Belgium</string>
-    <string name="np_desc_sncb">trains in Belgium</string>
+    <string name="np_desc_sncb">Trains in Belgium</string>
 
     <string name="np_region_br">Brazil</string>
     <string name="np_name_br">Brazil</string>
@@ -226,7 +226,7 @@ there are any).</string>
 
     <string name="np_region_europe">Europe</string>
     <string name="np_name_rt">Europe</string>
-    <string name="np_desc_rt">long-distance trains only</string>
+    <string name="np_desc_rt">Long-distance trains only</string>
     <string name="np_desc_rt_networks">Railteam alliance</string>
 
     <string name="np_region_finland">Finland</string>
@@ -289,7 +289,6 @@ there are any).</string>
     <string name="np_desc_vrn">Baden-Württemberg, Rheinland-Pfalz, Mannheim, Mainz, Trier</string>
     <string name="np_desc_vrr">North Rhine-Westphalia, Köln, Bonn, Essen, Dortmund, Düsseldorf, Münster, Paderborn, Höxter</string>
     <string name="np_desc_vrs">Cologne, Bonn</string>
-    <string name="np_name_vvm" translatable="false">move</string>
     <string name="np_desc_vvm">Swabia, Mittelschwaben, Krumbach, Günzburg, Memmingen</string>
     <string name="np_desc_vvo">Saxony, Dresden</string>
     <string name="np_desc_vvs">Baden-Württemberg, Stuttgart</string>
@@ -337,13 +336,11 @@ there are any).</string>
 
     <string name="np_region_sweden">Sweden</string>
     <string name="np_desc_se">Sweden, Stockholm</string>
-    <string name="np_name_stockholm">Stockholm</string>
-    <string name="np_desc_stockholm">Stockholm</string>
 
     <string name="np_region_switzerland">Switzerland</string>
     <!-- SBB is german/international, CFF is french and FFS is italian! So this IS translatable. -->
     <string name="np_name_sbb" translatable="true">SBB</string>
-    <string name="np_desc_sbb">trains in Switzerland</string>
+    <string name="np_desc_sbb">Trains in Switzerland</string>
     <string name="np_desc_vbl">Luzern</string>
     <string name="np_desc_zvv">Zurich</string>
 
@@ -354,7 +351,7 @@ there are any).</string>
     <string name="np_region_usa">United States of America</string>
     <string name="np_name_rtachicago">RTA</string>
     <string name="np_desc_rtachicago">Chicago</string>
-    <string name="np_desc_rtachicago_networks" translatable="false">cta, Metra, pace</string>
+    <string name="np_desc_rtachicago_networks" translatable="false">CTA, Metra, Pace</string>
     <string name="np_desc_septa">Bucks, Chester, Delaware, Montgomery and Philadelphia Counties</string>
     <string name="np_name_sf">San Francisco Bay Area</string>
     <string name="np_desc_sf">Alameda, Contra Costa, Marin, Napa, Solano, Sonoma, San Francisco, San Mateo and Santa Clara Counties</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -183,134 +183,152 @@ there are any).</string>
     <string name="changelog_title">What\'s New</string>
     <string name="changelog_show_full">More…</string>
 
+    <string name="np_region_australia">Australia</string>
+    <string name="np_desc_met">Australia, Victoria, Melbourne</string>
+    <string name="np_name_sydney">Sydney</string>
+    <string name="np_desc_sydney">Australia, New South Wales, Sydney</string>
+
+    <string name="np_region_austria">Austria</string>
+    <string name="np_desc_ivb">Innsbruck</string>
+    <string name="np_desc_linz">Upper Austria, Linz</string>
+    <string name="np_desc_oebb">Austria</string>
+    <string name="np_desc_stv">Steiermark, Graz, Marburg, Maribor</string>
+    <string name="np_desc_svv">Salzburg</string>
+    <string name="np_desc_vor">Lower Austria, Burgenland, Wien</string>
+    <string name="np_desc_vvt">Tirol</string>
+    <string name="np_name_wien">Vienna</string>
+    <string name="np_desc_wien">WIENER LINIEN</string>
+
+    <string name="np_region_belgium">Belgium</string>
+
+    <string name="np_region_br">Brazil</string>
+    <string name="np_name_br">Brazil</string>
+    <string name="np_desc_br">São Paulo, Rio de Janeiro, Belo Horizonte and Porto Alegre</string>
+    <string name="np_name_br_floripa">Florianópolis</string>
+    <string name="np_desc_br_floripa" translatable="false">SIM</string>
+
+    <string name="np_region_canada">Canada</string>
+    <string name="np_name_ontario">Ontario</string>
+    <string name="np_desc_ontario">Ottawa, Toronto</string>
+    <string name="np_name_quebec">Quebec</string>
+    <string name="np_desc_quebec">Deux-Montagnes, Laval, L\'Assomption, Outaouais, Sud-Ouest, Quebec, Haut-Saint-Laurent, Lanaudière, La Presqu\'Île, Laurentides, Montreal, Les Moulins, Vallée du Richelieu, Chambly-Richelieu-Carignan, Roussillon, Sorel-Varennes, Le Richelain, Sherbrooke, Sainte-Julie</string>
+
+    <string name="np_region_denmark">Denmark</string>
+    <string name="np_desc_dsb">Denmark, Copenhagen</string>
+
     <string name="np_region_europe">Europe</string>
     <string name="np_name_rt">Europe</string>
     <string name="np_desc_rt">long-distance trains only</string>
     <string name="np_desc_rt_networks">Railteam alliance</string>
 
-    <string name="np_region_germany">Germany</string>
-    <string name="np_desc_db">Most of Germany</string>
-    <string name="np_desc_bvg">Berlin</string>
-    <string name="np_desc_vbb">Brandenburg, Berlin</string>
-    <string name="np_desc_bayern">Bayern, Würzburg, Regensburg</string>
-    <string name="np_desc_avv">Augsburg</string>
-    <string name="np_desc_mvv">Bavaria, Munich</string>
-    <string name="np_desc_invg">Ingolstadt</string>
-    <string name="np_desc_vgn">Nuremberg, Fürth, Erlangen</string>
-    <string name="np_desc_vvm">Swabia, Mittelschwaben, Krumbach, Günzburg, Memmingen</string>
-    <string name="np_desc_vmv">Mecklenburg-Vorpommern, Schwerin</string>
-    <string name="np_desc_rsag" tools:keep="@string/np_desc_rsag">Rostock</string>
-    <string name="np_desc_hvv" tools:keep="@string/np_desc_hvv">Hamburg</string>
-    <string name="np_desc_sh">Schleswig-Holstein, Kiel, Lübeck, Hamburg</string>
-    <string name="np_desc_gvh">Lower Saxony, Hannover, Hamburg</string>
-    <string name="np_desc_bsvag">Braunschweig, Wolfsburg</string>
-    <string name="np_desc_vbn" tools:keep="@string/np_desc_vbn">Lower Saxony, Bremen, Bremerhaven, Oldenburg (Oldenburg), Osnabrück</string>
-    <string name="np_desc_vvo">Saxony, Dresden</string>
-    <string name="np_desc_vms">Mittelsachsen, Chemnitz</string>
-    <string name="np_desc_nasa">Saxony, Leipzig, Sachsen-Anhalt, Magdeburg, Halle</string>
-    <string name="np_desc_vrr">North Rhine-Westphalia, Köln, Bonn, Essen, Dortmund, Düsseldorf, Münster, Paderborn, Höxter</string>
-    <string name="np_desc_mvg">Märkischer Kreis, Lüdenscheid</string>
-    <string name="np_desc_nvv">Hesse, Frankfurt am Main, Kassel</string>
-    <string name="np_desc_vrn">Baden-Württemberg, Rheinland-Pfalz, Mannheim, Mainz, Trier</string>
-    <string name="np_desc_vvs">Baden-Württemberg, Stuttgart</string>
-    <string name="np_desc_ding">Baden-Württemberg, Ulm, Neu-Ulm</string>
-    <string name="np_desc_kvv">Baden-Württemberg, Karlsruhe</string>
-    <string name="np_desc_vagfr">Elsass, Bas-Rhin, Straßburg, Freiburg im Breisgau</string>
-    <string name="np_desc_nvbw">Baden-Württemberg, Konstanz, Basel, Basel-Stadt, Reutlingen, Rottweil, Tübingen, Sigmaringen</string>
-    <string name="np_desc_vvv">Vogtland, Plauen</string>
-    <string name="np_desc_vgs">Saarland, Saarbrücken</string>
+    <string name="np_region_finland">Finland</string>
+    <string name="np_desc_hsl">Helsinki</string>
 
-    <string name="np_region_austria">Austria</string>
-    <string name="np_desc_oebb">Austria</string>
-    <string name="np_desc_vor">Lower Austria, Burgenland, Wien</string>
-    <string name="np_desc_linz">Upper Austria, Linz</string>
-    <string name="np_desc_svv">Salzburg</string>
-    <string name="np_desc_vvt">Tirol</string>
-    <string name="np_desc_ivb">Innsbruck</string>
-    <string name="np_desc_stv">Steiermark, Graz, Marburg, Maribor</string>
-    <string name="np_desc_wien">WIENER LINIEN</string>
+    <string name="np_region_france">France</string>
+    <string name="np_name_francenortheast">France North East</string>
+    <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>
+    <string name="np_desc_francenortheast_networks" translatable="false">SNCF, CTS, Transpole, STAN, LE MET</string>
+    <string name="np_name_francenorthwest">France North West</string>
+    <string name="np_desc_francenorthwest">Bretagne, Pays de la Loire, Centre, Basse Normandie, Haute Normandie</string>
+    <string name="np_desc_francenorthwest_networks" translatable="false">LILA, Star, TAN, IRIGO, SNCF</string>
+    <string name="np_name_frenchsouthwest">France South West</string>
+    <string name="np_desc_frenchsouthwest">Poitou-Charentes, Limousin, Aquitaine, Midi-Pyrénées, Bordeaux, Toulouse</string>
+    <string name="np_desc_frenchsouthwest_networks" translatable="false">SNCF, TransGironde, TBC, Tisséo</string>
+    <string name="np_desc_paca">Provence-Alpes-Côte d\'Azur</string>
+    <string name="np_name_paris">Paris</string>
+    <string name="np_desc_paris">Paris</string>
+
+    <string name="np_region_gb">Great Britain</string>
+    <string name="np_desc_mersey">Liverpool City Region</string>
+    <string name="np_desc_tlem">Greater London, Birmingham, Derbyshire, Leicestershire, Rutland, Northamptonshire, Nottinghamshire, Lincolnshire, Berkshire, Buckinghamshire, East Sussex, Hampshire, Isle of Wight, Kent, Oxfordshire, Surrey, West Sussex, Essex, Hertfordshire, Bedfordshire, Cambridgeshire, Norfolk, Suffolk, Somerset, Gloucestershire, Wiltshire, Dorset, Devon, Cornwall, West Devon, Stowford, Eastleigh, Swindon, Gloucester, Plymouth, Torbay, Bournemouth, Poole</string>
+    <string name="np_desc_tlwm" tools:keep="@string/np_desc_tlwm">Birmingham</string>
+
+    <string name="np_region_germany">Germany</string>
+    <string name="np_desc_avv">Augsburg</string>
+    <string name="np_name_bayern">Bavaria</string>
+    <string name="np_desc_bayern">Bayern, Würzburg, Regensburg</string>
+    <string name="np_desc_bsvag">Braunschweig, Wolfsburg</string>
+    <string name="np_desc_bvg">Berlin</string>
+    <string name="np_name_db" translatable="false">Deutsche Bahn</string>
+    <string name="np_desc_db">Most of Germany</string>
+    <string name="np_desc_ding">Baden-Württemberg, Ulm, Neu-Ulm</string>
+    <string name="np_desc_gvh">Lower Saxony, Hannover, Hamburg</string>
+    <string name="np_desc_hvv" tools:keep="@string/np_desc_hvv">Hamburg</string>
+    <string name="np_name_invg">Ingolstadt</string>
+    <string name="np_desc_invg">Ingolstadt</string>
+    <string name="np_desc_kvv">Baden-Württemberg, Karlsruhe</string>
+    <string name="np_desc_mvg">Märkischer Kreis, Lüdenscheid</string>
+    <string name="np_desc_mvv">Bavaria, Munich</string>
+    <string name="np_desc_nasa">Saxony, Leipzig, Sachsen-Anhalt, Magdeburg, Halle</string>
+    <string name="np_desc_nvbw">Baden-Württemberg, Konstanz, Basel, Basel-Stadt, Reutlingen, Rottweil, Tübingen, Sigmaringen</string>
+    <string name="np_desc_nvv">Hesse, Frankfurt am Main, Kassel</string>
+    <string name="np_desc_rsag" tools:keep="@string/np_desc_rsag">Rostock</string>
+    <string name="np_desc_sh">Schleswig-Holstein, Kiel, Lübeck, Hamburg</string>
+    <string name="np_desc_vagfr">Elsass, Bas-Rhin, Straßburg, Freiburg im Breisgau</string>
+    <string name="np_desc_vbb">Brandenburg, Berlin</string>
+    <string name="np_desc_vbn" tools:keep="@string/np_desc_vbn">Lower Saxony, Bremen, Bremerhaven, Oldenburg (Oldenburg), Osnabrück</string>
+    <string name="np_desc_vgn">Nuremberg, Fürth, Erlangen</string>
+    <string name="np_desc_vgs">Saarland, Saarbrücken</string>
+    <string name="np_desc_vms">Mittelsachsen, Chemnitz</string>
+    <string name="np_desc_vmv">Mecklenburg-Vorpommern, Schwerin</string>
+    <string name="np_desc_vrn">Baden-Württemberg, Rheinland-Pfalz, Mannheim, Mainz, Trier</string>
+    <string name="np_desc_vrr">North Rhine-Westphalia, Köln, Bonn, Essen, Dortmund, Düsseldorf, Münster, Paderborn, Höxter</string>
+    <string name="np_desc_vrs">Cologne, Bonn</string>
+    <string name="np_desc_vvm">Swabia, Mittelschwaben, Krumbach, Günzburg, Memmingen</string>
+    <string name="np_desc_vvo">Saxony, Dresden</string>
+    <string name="np_desc_vvs">Baden-Württemberg, Stuttgart</string>
+    <string name="np_desc_vvv">Vogtland, Plauen</string>
+
+    <string name="np_region_ireland">Ireland</string>
+    <string name="np_desc_tfi">Ireland, Dublin, Belfast</string>
+
+    <string name="np_region_israel">Israel</string>
+    <string name="np_desc_jet">Israel, Jerusalem</string>
+
+    <string name="np_region_italy">Italy</string>
+    <string name="np_desc_atc">Emilia-Romagna, Bologna</string>
+    <string name="np_desc_it">Roma, Milano, Torino, Venezia, Palermo, Trento</string>
+    <string name="np_desc_it_networks" translatable="false">ATM, GTT, AMAT, ACTV</string>
 
     <string name="np_region_liechtenstein">Liechtenstein</string>
     <string name="np_desc_vmobil">Liechtenstein, Vorarlberg, Bregenz</string>
+
+    <string name="np_region_luxembourg">Luxembourg</string>
+
+    <string name="np_region_netherlands">Netherlands</string>
+    <string name="np_desc_ns">Netherlands, Amsterdam</string>
+
+    <string name="np_region_norway">Norway</string>
+    <string name="np_desc_nri">Norway, Oslo, Bergen</string>
+
+    <string name="np_region_nz">New Zealand</string>
+    <string name="np_desc_nz">Wellington, Auckland</string>
+
+    <string name="np_region_poland">Poland</string>
+    <string name="np_desc_pl">Poland, railways in Poland</string>
+
+    <string name="np_region_spain">Spain</string>
+    <string name="np_name_spain">Spain</string>
+    <string name="np_desc_spain">Madrid buses (EMT), Barcelona (TMB), Basque (Moveuskadi)</string>
+
+    <string name="np_region_sweden">Sweden</string>
+    <string name="np_desc_se">Sweden, Stockholm</string>
+    <string name="np_name_stockholm">Stockholm</string>
+    <string name="np_desc_stockholm">Stockholm</string>
 
     <string name="np_region_switzerland">Switzerland</string>
     <string name="np_desc_vbl">Luzern</string>
     <string name="np_desc_zvv">Zurich</string>
 
-    <string name="np_region_belgium">Belgium</string>
-    <string name="np_region_luxembourg">Luxembourg</string>
-    <string name="np_region_netherlands">Netherlands</string>
-    <string name="np_region_denmark">Denmark</string>
-    <string name="np_region_sweden">Sweden</string>
-    <string name="np_region_norway">Norway</string>
-    <string name="np_region_gb">Great Britain</string>
-    <string name="np_region_ireland">Ireland</string>
-    <string name="np_region_italy">Italy</string>
-    <string name="np_region_poland">Poland</string>
     <string name="np_region_uae">United Arab Emirates</string>
-    <string name="np_region_usa">United States of America</string>
-    <string name="np_region_australia">Australia</string>
-    <string name="np_region_israel">Israel</string>
-    <string name="np_region_france">France</string>
-    <string name="np_region_finland">Finland</string>
-    <string name="np_region_nz">New Zealand</string>
-    <string name="np_region_spain">Spain</string>
-    <string name="np_region_br">Brazil</string>
-    <string name="np_region_canada">Canada</string>
-
-    <string name="np_desc_ns">Netherlands, Amsterdam</string>
-    <string name="np_desc_dsb">Denmark, Copenhagen</string>
-    <string name="np_desc_se">Sweden, Stockholm</string>
-    <string name="np_desc_stockholm">Stockholm</string>
-    <string name="np_desc_nri">Norway, Oslo, Bergen</string>
-    <string name="np_desc_tlem">Greater London, Birmingham, Derbyshire, Leicestershire, Rutland, Northamptonshire, Nottinghamshire, Lincolnshire, Berkshire, Buckinghamshire, East Sussex, Hampshire, Isle of Wight, Kent, Oxfordshire, Surrey, West Sussex, Essex, Hertfordshire, Bedfordshire, Cambridgeshire, Norfolk, Suffolk, Somerset, Gloucestershire, Wiltshire, Dorset, Devon, Cornwall, West Devon, Stowford, Eastleigh, Swindon, Gloucester, Plymouth, Torbay, Bournemouth, Poole</string>
-    <string name="np_desc_tlwm" tools:keep="@string/np_desc_tlwm">Birmingham</string>
-    <string name="np_desc_tfi">Ireland, Dublin, Belfast</string>
-    <string name="np_desc_atc">Emilia-Romagna, Bologna</string>
-    <string name="np_desc_pl">Poland, railways in Poland</string>
     <string name="np_desc_dub">United Arab Emirates, Dubai</string>
-    <string name="np_desc_sf">California, San Francisco</string>
-    <string name="np_desc_septa">Pennsylvania, Philadelphia</string>
-    <string name="np_desc_sydney">Australia, New South Wales, Sydney</string>
-    <string name="np_desc_met">Australia, Victoria, Melbourne</string>
-    <string name="np_desc_jet">Israel, Jerusalem</string>
-    <string name="np_desc_paca">Provence-Alpes-Côte d\'Azur</string>
-    <string name="np_desc_hsl">Helsinki</string>
-    <string name="np_desc_paris">Paris</string>
-    <string name="np_desc_nz">Wellington, Auckland</string>
-    <string name="np_desc_usny" tools:keep="@string/np_desc_usny">MTA, CDTA, Port Authority, Staten Island Ferry, NFTA, Rockland County, Rochester-Genesee Regional Transportation Authority</string>
-    <string name="np_desc_spain">Madrid buses (EMT), Barcelona (TMB), Basque (Moveuskadi)</string>
-    <string name="np_desc_mersey">Liverpool City Region</string>
-    <string name="np_desc_br">São Paulo, Rio de Janeiro, Belo Horizonte and Porto Alegre</string>
-    <string name="np_desc_br_floripa" translatable="false">SIM</string>
-    <string name="np_desc_vrs">Cologne, Bonn</string>
-    <string name="np_desc_frenchsouthwest">Poitou-Charentes, Limousin, Aquitaine, Midi-Pyrénées, Bordeaux, Toulouse</string>
-    <string name="np_desc_frenchsouthwest_networks" translatable="false">SNCF, TransGironde, TBC, Tisséo</string>
-    <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>
-    <string name="np_desc_francenortheast_networks" translatable="false">SNCF, CTS, Transpole, STAN, LE MET</string>
-    <string name="np_desc_francenorthwest">Bretagne, Pays de la Loire, Centre, Basse Normandie, Haute Normandie</string>
-    <string name="np_desc_francenorthwest_networks" translatable="false">LILA, Star, TAN, IRIGO, SNCF</string>
-    <string name="np_desc_it">Roma, Milano, Torino, Venezia, Palermo, Trento</string>
-    <string name="np_desc_it_networks" translatable="false">ATM, GTT, AMAT, ACTV</string>
-    <string name="np_desc_ontario">Ottawa, Toronto</string>
-    <string name="np_desc_quebec">Deux-Montagnes, Laval, L\'Assomption, Outaouais, Sud-Ouest, Quebec, Haut-Saint-Laurent, Lanaudière, La Presqu\'Île, Laurentides, Montreal, Les Moulins, Vallée du Richelieu, Chambly-Richelieu-Carignan, Roussillon, Sorel-Varennes, Le Richelain, Sherbrooke, Sainte-Julie</string>
 
-    <string name="np_name_db">Deutsche Bahn</string>
-    <string name="np_name_bayern">BAVARIA</string>
-    <string name="np_name_paris">PARIS</string>
-    <string name="np_name_sydney">SYDNEY</string>
-    <string name="np_name_stockholm">STOCKHOLM</string>
-    <string name="np_name_wien">VIENNA</string>
-    <string name="np_name_spain">Spain</string>
-    <string name="np_name_usny" tools:keep="@string/np_name_usny">New York and New-Jersey States</string>
-    <string name="np_name_br">Brazil</string>
-    <string name="np_name_br_floripa">Florianópolis</string>
-    <string name="np_name_frenchsouthwest">France South West</string>
-    <string name="np_name_francenortheast">France North East</string>
-    <string name="np_name_francenorthwest">France North West</string>
-    <string name="np_name_ontario">Ontario</string>
-    <string name="np_name_quebec">Quebec</string>
+    <string name="np_region_usa">United States of America</string>
     <string name="np_name_rtachicago">Chicago</string>
+    <string name="np_desc_septa">Pennsylvania, Philadelphia</string>
+    <string name="np_desc_sf">California, San Francisco</string>
+    <string name="np_name_usny" tools:keep="@string/np_name_usny">New York and New-Jersey States</string>
+    <string name="np_desc_usny" tools:keep="@string/np_desc_usny">MTA, CDTA, Port Authority, Staten Island Ferry, NFTA, Rockland County, Rochester-Genesee Regional Transportation Authority</string>
 
     <string name="maintainer">Maintainer</string>
     <string name="contributors">Contributors</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -327,7 +327,7 @@ there are any).</string>
     <string name="np_desc_nz_networks" translatable="false">Go Welligton, Tranz Metro, Auckland Transport</string>
 
     <string name="np_region_poland">Poland</string>
-    <string name="np_name_pl" translatable="false">Bilkom</string>
+    <string name="np_name_pl" translatable="false">PKP</string>
     <string name="np_desc_pl">Poland, railways in Poland</string>
 
     <string name="np_region_spain">Spain</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -185,7 +185,8 @@ there are any).</string>
 
     <string name="np_region_europe">Europe</string>
     <string name="np_name_rt">Europe</string>
-    <string name="np_desc_rt">long-distance only</string>
+    <string name="np_desc_rt">long-distance trains only</string>
+    <string name="np_desc_rt_networks">Railteam alliance</string>
 
     <string name="np_region_germany">Germany</string>
     <string name="np_desc_db">Most of Germany</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -184,34 +184,42 @@ there are any).</string>
     <string name="changelog_show_full">More…</string>
 
     <string name="np_region_australia">Australia</string>
+    <string name="np_name_met" translatable="false">PTV</string>
     <string name="np_desc_met">Australia, Victoria, Melbourne</string>
-    <string name="np_name_sydney">Sydney</string>
+    <string name="np_name_sydney" translatable="false">Transport NSW</string>
     <string name="np_desc_sydney">Australia, New South Wales, Sydney</string>
 
     <string name="np_region_austria">Austria</string>
     <string name="np_desc_ivb">Innsbruck</string>
+    <string name="np_name_linz" translatable="false">Linz AG Linien</string>
     <string name="np_desc_linz">Upper Austria, Linz</string>
+    <string name="np_name_oebb" translatable="false">ÖBB</string>
     <string name="np_desc_oebb">Austria</string>
+    <string name="np_name_stv" translatable="false">STV Verbund Linie</string>
     <string name="np_desc_stv">Steiermark, Graz, Marburg, Maribor</string>
     <string name="np_desc_svv">Salzburg</string>
     <string name="np_desc_vor">Lower Austria, Burgenland, Wien</string>
     <string name="np_desc_vvt">Tirol</string>
-    <string name="np_name_wien">Vienna</string>
-    <string name="np_desc_wien">WIENER LINIEN</string>
+    <string name="np_name_wien" translatable="false">Wiener Linien</string>
+    <string name="np_desc_wien">Vienna</string>
 
     <string name="np_region_belgium">Belgium</string>
+    <string name="np_desc_sncb">trains in Belgium</string>
 
     <string name="np_region_br">Brazil</string>
     <string name="np_name_br">Brazil</string>
     <string name="np_desc_br">São Paulo, Rio de Janeiro, Belo Horizonte and Porto Alegre</string>
-    <string name="np_name_br_floripa">Florianópolis</string>
-    <string name="np_desc_br_floripa" translatable="false">SIM</string>
+    <string name="np_desc_br_networks" translatable="false">EPTC, SPTRANS, Buenosaires Subtes</string>
+    <string name="np_name_br_floripa" translatable="false">SIM</string>
+    <string name="np_desc_br_floripa">Florianópolis</string>
 
     <string name="np_region_canada">Canada</string>
     <string name="np_name_ontario">Ontario</string>
-    <string name="np_desc_ontario">Ottawa, Toronto</string>
+    <string name="np_desc_ontario">Ontario, Ottawa, Toronto</string>
+    <string name="np_desc_ontario_networks" translatable="false">Toronto Transit Commission - TTC, OC Transpo</string>
     <string name="np_name_quebec">Quebec</string>
     <string name="np_desc_quebec">Deux-Montagnes, Laval, L\'Assomption, Outaouais, Sud-Ouest, Quebec, Haut-Saint-Laurent, Lanaudière, La Presqu\'Île, Laurentides, Montreal, Les Moulins, Vallée du Richelieu, Chambly-Richelieu-Carignan, Roussillon, Sorel-Varennes, Le Richelain, Sherbrooke, Sainte-Julie</string>
+    <string name="np_desc_quebec_networks" translatable="false">AMT, STM, STL</string>
 
     <string name="np_region_denmark">Denmark</string>
     <string name="np_desc_dsb">Denmark, Copenhagen</string>
@@ -236,44 +244,52 @@ there are any).</string>
     <string name="np_desc_frenchsouthwest_networks" translatable="false">SNCF, TransGironde, TBC, Tisséo</string>
     <string name="np_desc_paca">Provence-Alpes-Côte d\'Azur</string>
     <string name="np_name_paris">Paris</string>
-    <string name="np_desc_paris">Paris</string>
+    <string name="np_desc_paris">Ile-de-France, France, Paris</string>
+    <string name="np_desc_paris_networks" translatable="false">RATP, SNCF, Transilien, STIF</string>
 
     <string name="np_region_gb">Great Britain</string>
+    <string name="np_name_mersey" translatable="false">Merseytravel</string>
     <string name="np_desc_mersey">Liverpool City Region</string>
     <string name="np_desc_tlem">Greater London, Birmingham, Derbyshire, Leicestershire, Rutland, Northamptonshire, Nottinghamshire, Lincolnshire, Berkshire, Buckinghamshire, East Sussex, Hampshire, Isle of Wight, Kent, Oxfordshire, Surrey, West Sussex, Essex, Hertfordshire, Bedfordshire, Cambridgeshire, Norfolk, Suffolk, Somerset, Gloucestershire, Wiltshire, Dorset, Devon, Cornwall, West Devon, Stowford, Eastleigh, Swindon, Gloucester, Plymouth, Torbay, Bournemouth, Poole</string>
     <string name="np_desc_tlwm" tools:keep="@string/np_desc_tlwm">Birmingham</string>
 
     <string name="np_region_germany">Germany</string>
     <string name="np_desc_avv">Augsburg</string>
-    <string name="np_name_bayern">Bavaria</string>
+    <string name="np_name_bayern" translatable="false">BEG</string>
     <string name="np_desc_bayern">Bayern, Würzburg, Regensburg</string>
+    <string name="np_name_bsvag" translatable="false">BSVG</string>
     <string name="np_desc_bsvag">Braunschweig, Wolfsburg</string>
     <string name="np_desc_bvg">Berlin</string>
     <string name="np_name_db" translatable="false">Deutsche Bahn</string>
     <string name="np_desc_db">Most of Germany</string>
     <string name="np_desc_ding">Baden-Württemberg, Ulm, Neu-Ulm</string>
-    <string name="np_desc_gvh">Lower Saxony, Hannover, Hamburg</string>
+    <string name="np_desc_gvh">Lower Saxony, Hannover, Hamburg, Bremerhaven</string>
     <string name="np_desc_hvv" tools:keep="@string/np_desc_hvv">Hamburg</string>
     <string name="np_name_invg">Ingolstadt</string>
     <string name="np_desc_invg">Ingolstadt</string>
     <string name="np_desc_kvv">Baden-Württemberg, Karlsruhe</string>
     <string name="np_desc_mvg">Märkischer Kreis, Lüdenscheid</string>
     <string name="np_desc_mvv">Bavaria, Munich</string>
+    <string name="np_name_nasa" translatable="false">INSA</string>
     <string name="np_desc_nasa">Saxony, Leipzig, Sachsen-Anhalt, Magdeburg, Halle</string>
     <string name="np_desc_nvbw">Baden-Württemberg, Konstanz, Basel, Basel-Stadt, Reutlingen, Rottweil, Tübingen, Sigmaringen</string>
+    <string name="np_name_nvv" translatable="false">NVV/RMV</string>
     <string name="np_desc_nvv">Hesse, Frankfurt am Main, Kassel</string>
     <string name="np_desc_rsag" tools:keep="@string/np_desc_rsag">Rostock</string>
     <string name="np_desc_sh">Schleswig-Holstein, Kiel, Lübeck, Hamburg</string>
+    <string name="np_name_vagfr" translatable="false">VAG</string>
     <string name="np_desc_vagfr">Elsass, Bas-Rhin, Straßburg, Freiburg im Breisgau</string>
     <string name="np_desc_vbb">Brandenburg, Berlin</string>
     <string name="np_desc_vbn" tools:keep="@string/np_desc_vbn">Lower Saxony, Bremen, Bremerhaven, Oldenburg (Oldenburg), Osnabrück</string>
-    <string name="np_desc_vgn">Nuremberg, Fürth, Erlangen</string>
+    <string name="np_desc_vgn">Nuremberg, Fürth, Erlangen, Bayreuth, Bamberg, Schwabach</string>
+    <string name="np_desc_vgn_networks" translatable="false">VAG, DB, ESTW, infra fürth, Stadtwerke Bayreuth, Stadtwerke Schwabach, STWB, GPV, GkV</string>
     <string name="np_desc_vgs">Saarland, Saarbrücken</string>
     <string name="np_desc_vms">Mittelsachsen, Chemnitz</string>
     <string name="np_desc_vmv">Mecklenburg-Vorpommern, Schwerin</string>
     <string name="np_desc_vrn">Baden-Württemberg, Rheinland-Pfalz, Mannheim, Mainz, Trier</string>
     <string name="np_desc_vrr">North Rhine-Westphalia, Köln, Bonn, Essen, Dortmund, Düsseldorf, Münster, Paderborn, Höxter</string>
     <string name="np_desc_vrs">Cologne, Bonn</string>
+    <string name="np_name_vvm" translatable="false">move</string>
     <string name="np_desc_vvm">Swabia, Mittelschwaben, Krumbach, Günzburg, Memmingen</string>
     <string name="np_desc_vvo">Saxony, Dresden</string>
     <string name="np_desc_vvs">Baden-Württemberg, Stuttgart</string>
@@ -282,11 +298,12 @@ there are any).</string>
     <string name="np_region_ireland">Ireland</string>
     <string name="np_desc_tfi">Ireland, Dublin, Belfast</string>
 
-    <string name="np_region_israel">Israel</string>
-    <string name="np_desc_jet">Israel, Jerusalem</string>
+    <string name="np_region_israel" tools:keep="@string/np_region_israel">Israel</string>
+    <string name="np_desc_jet" tools:keep="@string/np_desc_jet">Israel, Jerusalem</string>
 
     <string name="np_region_italy">Italy</string>
     <string name="np_desc_atc">Emilia-Romagna, Bologna</string>
+    <string name="np_name_it">Italy</string>
     <string name="np_desc_it">Roma, Milano, Torino, Venezia, Palermo, Trento</string>
     <string name="np_desc_it_networks" translatable="false">ATM, GTT, AMAT, ACTV</string>
 
@@ -294,6 +311,9 @@ there are any).</string>
     <string name="np_desc_vmobil">Liechtenstein, Vorarlberg, Bregenz</string>
 
     <string name="np_region_luxembourg">Luxembourg</string>
+    <string name="np_name_lu" translatable="false">Verkéiersverbond</string>
+    <string name="np_desc_lu">Luxembourg</string>
+    <string name="np_desc_lu_networks" translatable="false">AVL, SNCFL, FLEAA, RGTR, TICE</string>
 
     <string name="np_region_netherlands">Netherlands</string>
     <string name="np_desc_ns">Netherlands, Amsterdam</string>
@@ -302,14 +322,18 @@ there are any).</string>
     <string name="np_desc_nri">Norway, Oslo, Bergen</string>
 
     <string name="np_region_nz">New Zealand</string>
-    <string name="np_desc_nz">Wellington, Auckland</string>
+    <string name="np_name_nz">New Zealand</string>
+    <string name="np_desc_nz">New-Zealand, Welligton, Auckland</string>
+    <string name="np_desc_nz_networks" translatable="false">Go Welligton, Tranz Metro, Auckland Transport</string>
 
     <string name="np_region_poland">Poland</string>
+    <string name="np_name_pl" translatable="false">Bilkom</string>
     <string name="np_desc_pl">Poland, railways in Poland</string>
 
     <string name="np_region_spain">Spain</string>
     <string name="np_name_spain">Spain</string>
-    <string name="np_desc_spain">Madrid buses (EMT), Barcelona (TMB), Basque (Moveuskadi)</string>
+    <string name="np_desc_spain">Madrid buses, Barcelona, Basque</string>
+    <string name="np_desc_spain_networks" translatable="false">EMT, TMB, Moveuskadi</string>
 
     <string name="np_region_sweden">Sweden</string>
     <string name="np_desc_se">Sweden, Stockholm</string>
@@ -317,18 +341,25 @@ there are any).</string>
     <string name="np_desc_stockholm">Stockholm</string>
 
     <string name="np_region_switzerland">Switzerland</string>
+    <!-- SBB is german/international, CFF is french and FFS is italian! So this IS translatable. -->
+    <string name="np_name_sbb" translatable="true">SBB</string>
+    <string name="np_desc_sbb">trains in Switzerland</string>
     <string name="np_desc_vbl">Luzern</string>
     <string name="np_desc_zvv">Zurich</string>
 
     <string name="np_region_uae">United Arab Emirates</string>
+    <string name="np_name_dub">Dubai</string>
     <string name="np_desc_dub">United Arab Emirates, Dubai</string>
 
     <string name="np_region_usa">United States of America</string>
-    <string name="np_name_rtachicago">Chicago</string>
-    <string name="np_desc_septa">Pennsylvania, Philadelphia</string>
-    <string name="np_desc_sf">California, San Francisco</string>
+    <string name="np_name_rtachicago">RTA</string>
+    <string name="np_desc_rtachicago">Chicago</string>
+    <string name="np_desc_rtachicago_networks" translatable="false">cta, Metra, pace</string>
+    <string name="np_desc_septa">Bucks, Chester, Delaware, Montgomery and Philadelphia Counties</string>
+    <string name="np_name_sf">San Francisco Bay Area</string>
+    <string name="np_desc_sf">Alameda, Contra Costa, Marin, Napa, Solano, Sonoma, San Francisco, San Mateo and Santa Clara Counties</string>
     <string name="np_name_usny" tools:keep="@string/np_name_usny">New York and New-Jersey States</string>
-    <string name="np_desc_usny" tools:keep="@string/np_desc_usny">MTA, CDTA, Port Authority, Staten Island Ferry, NFTA, Rockland County, Rochester-Genesee Regional Transportation Authority</string>
+    <string name="np_desc_usny" translatable="false" tools:keep="@string/np_desc_usny">MTA, CDTA, Port Authority, Staten Island Ferry, NFTA, Rockland County, Rochester-Genesee Regional Transportation Authority</string>
 
     <string name="maintainer">Maintainer</string>
     <string name="contributors">Contributors</string>

--- a/src/de/grobox/liberario/TransportNetwork.java
+++ b/src/de/grobox/liberario/TransportNetwork.java
@@ -57,6 +57,12 @@ public class TransportNetwork {
 		return this;
 	}
 
+	public TransportNetwork setDescription(@Nullable String description, @Nullable String networks) {
+		this.description = description + "\n(" + networks + ")";
+
+		return this;
+	}
+
 	public TransportNetwork setRegion(@Nullable String region) {
 		this.region = region;
 

--- a/src/de/grobox/liberario/TransportNetwork.java
+++ b/src/de/grobox/liberario/TransportNetwork.java
@@ -57,7 +57,7 @@ public class TransportNetwork {
 		return this;
 	}
 
-	public TransportNetwork setDescription(@Nullable String description, @Nullable String networks) {
+	public TransportNetwork setDescription(String description, String networks) {
 		this.description = description + "\n(" + networks + ")";
 
 		return this;

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -49,11 +49,11 @@ public class TransportNetworks {
 		list.add(new TransportNetwork(context, NetworkId.RT)
 				         .setName(getString(R.string.np_name_rt))
 				         .setDescription(getString(R.string.np_desc_rt))
-				         .setRegion(getString(R.string.np_region_europe) + " \uD83C\uDDEA\uD83C\uDDFA")
+				         .setRegion(region(getString(R.string.np_region_europe), "\uD83C\uDDEA\uD83C\uDDFA"))
 		);
 
 		// Germany
-		region = getString(R.string.np_region_germany) + " \uD83C\uDDE9\uD83C\uDDEA";
+		region = region(getString(R.string.np_region_germany), "\uD83C\uDDE9\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.DB)
 				         .setName(getString(R.string.np_name_db))
@@ -215,7 +215,7 @@ public class TransportNetworks {
 		);
 
 		// Austria
-		region = getString(R.string.np_region_austria) + " \uD83C\uDDE6\uD83C\uDDF9";
+		region = region(getString(R.string.np_region_austria), "\uD83C\uDDE6\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.OEBB)
 				         .setDescription(getString(R.string.np_desc_oebb))
@@ -254,7 +254,7 @@ public class TransportNetworks {
 		);
 
 		// Liechtenstein
-		region = getString(R.string.np_region_liechtenstein) + " \uD83C\uDDF1\uD83C\uDDEE";
+		region = region(getString(R.string.np_region_liechtenstein), "\uD83C\uDDF1\uD83C\uDDEE");
 
 		list.add(new TransportNetwork(context, NetworkId.VAO)
 				         .setDescription(getString(R.string.np_desc_vmobil))
@@ -262,7 +262,7 @@ public class TransportNetworks {
 		);
 
 		// Switzerland
-		region = getString(R.string.np_region_switzerland) + " \uD83C\uDDE8\uD83C\uDDED";
+		region = region(getString(R.string.np_region_switzerland), "\uD83C\uDDE8\uD83C\uDDED");
 
 		list.add(new TransportNetwork(context, NetworkId.SBB)
 				         .setRegion(region)
@@ -283,21 +283,21 @@ public class TransportNetworks {
 		);
 
 		// Belgium
-		region = getString(R.string.np_region_belgium) + " \uD83C\uDDE7\uD83C\uDDEA";
+		region = region(getString(R.string.np_region_belgium), "\uD83C\uDDE7\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.SNCB)
 				         .setRegion(region)
 		);
 
 		// Luxembourg
-		region = getString(R.string.np_region_luxembourg) + " \uD83C\uDDF1\uD83C\uDDFA";
+		region = region(getString(R.string.np_region_luxembourg), "\uD83C\uDDF1\uD83C\uDDFA");
 
 		list.add(new TransportNetwork(context, NetworkId.LU)
 				         .setRegion(region)
 		);
 
 		// Netherlands
-		region = getString(R.string.np_region_netherlands) + " \uD83C\uDDF3\uD83C\uDDF1";
+		region = region(getString(R.string.np_region_netherlands), "\uD83C\uDDF3\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.NS)
 				         .setDescription(getString(R.string.np_desc_ns))
@@ -306,7 +306,7 @@ public class TransportNetworks {
 		);
 
 		// Denmark
-		region = getString(R.string.np_region_denmark) + " \uD83C\uDDE9\uD83C\uDDF0";
+		region = region(getString(R.string.np_region_denmark), "\uD83C\uDDE9\uD83C\uDDF0");
 
 		list.add(new TransportNetwork(context, NetworkId.DSB)
 				         .setDescription(getString(R.string.np_desc_dsb))
@@ -314,7 +314,7 @@ public class TransportNetworks {
 		);
 
 		// Sweden
-		region = getString(R.string.np_region_sweden) + " \uD83C\uDDF8\uD83C\uDDEA";
+		region = region(getString(R.string.np_region_sweden), "\uD83C\uDDF8\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.SE)
 				         .setDescription(getString(R.string.np_desc_se))
@@ -330,7 +330,7 @@ public class TransportNetworks {
 		);
 */
 		// Norway
-		region = getString(R.string.np_region_norway) + " \uD83C\uDDF3\uD83C\uDDF4";
+		region = region(getString(R.string.np_region_norway), "\uD83C\uDDF3\uD83C\uDDF4");
 
 		list.add(new TransportNetwork(context, NetworkId.NRI)
 				         .setDescription(getString(R.string.np_desc_nri))
@@ -338,7 +338,7 @@ public class TransportNetworks {
 		);
 
 		// Finland
-		region = getString(R.string.np_region_finland) + " \uD83C\uDDEB\uD83C\uDDEE";
+		region = region(getString(R.string.np_region_finland), "\uD83C\uDDEB\uD83C\uDDEE");
 
 		list.add(new TransportNetwork(context, NetworkId.HSL)
 				         .setDescription(getString(R.string.np_desc_hsl))
@@ -347,7 +347,7 @@ public class TransportNetworks {
 		);
 
 		// Great Britain
-		region = getString(R.string.np_region_gb) + " \uD83C\uDDEC\uD83C\uDDE7";
+		region = region(getString(R.string.np_region_gb), "\uD83C\uDDEC\uD83C\uDDE7");
 
 		list.add(new TransportNetwork(context, NetworkId.TLEM)
 				         .setDescription(getString(R.string.np_desc_tlem))
@@ -360,7 +360,7 @@ public class TransportNetworks {
 		);
 
 		// Ireland
-		region = getString(R.string.np_region_ireland) + " \uD83C\uDDEE\uD83C\uDDEA";
+		region = region(getString(R.string.np_region_ireland), "\uD83C\uDDEE\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.TFI)
 				         .setDescription(getString(R.string.np_desc_tfi))
@@ -373,7 +373,7 @@ public class TransportNetworks {
 		);
 */
 		// Italy
-		region = getString(R.string.np_region_italy) + " \uD83C\uDDEE\uD83C\uDDF9";
+		region = region(getString(R.string.np_region_italy), "\uD83C\uDDEE\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.IT)
 				.setDescription(getString(R.string.np_desc_it) + "\n(" + getString(R.string.np_desc_it_networks) + ")")
@@ -389,7 +389,7 @@ public class TransportNetworks {
 		);
 
 		// Poland
-		region = getString(R.string.np_region_poland) + " \uD83C\uDDF5\uD83C\uDDF1";
+		region = region(getString(R.string.np_region_poland), "\uD83C\uDDF5\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.PL)
 				         .setDescription(getString(R.string.np_desc_pl))
@@ -397,7 +397,7 @@ public class TransportNetworks {
 		);
 
 		// United Arabian Emirates
-		region = getString(R.string.np_region_uae) + " \uD83C\uDDE6\uD83C\uDDEA";
+		region = region(getString(R.string.np_region_uae), "\uD83C\uDDE6\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.DUB)
 				         .setDescription(getString(R.string.np_desc_dub))
@@ -406,7 +406,7 @@ public class TransportNetworks {
 		);
 
 		// United States of America
-		region = getString(R.string.np_region_usa) + " \uD83C\uDDFA\uD83C\uDDF8";
+		region = region(getString(R.string.np_region_usa), "\uD83C\uDDFA\uD83C\uDDF8");
 
 		list.add(new TransportNetwork(context, NetworkId.SF)
 				         .setDescription(getString(R.string.np_desc_sf))
@@ -434,7 +434,7 @@ public class TransportNetworks {
 		);
 */
 		// Australia
-		region = getString(R.string.np_region_australia) + " \uD83C\uDDE6\uD83C\uDDFA";
+		region = region(getString(R.string.np_region_australia), "\uD83C\uDDE6\uD83C\uDDFA");
 
 		list.add(new TransportNetwork(context, NetworkId.SYDNEY)
 				         .setName(getString(R.string.np_name_sydney))
@@ -448,7 +448,7 @@ public class TransportNetworks {
 		);
 
 		// Israel
-		region = getString(R.string.np_region_israel) + " \uD83C\uDDEE\uD83C\uDDF1";
+		region = region(getString(R.string.np_region_israel), "\uD83C\uDDEE\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.JET)
 				         .setDescription(getString(R.string.np_desc_jet))
@@ -456,7 +456,7 @@ public class TransportNetworks {
 		);
 
 		// France
-		region = getString(R.string.np_region_france) + " \uD83C\uDDEB\uD83C\uDDF7";
+		region = region(getString(R.string.np_region_france), "\uD83C\uDDEB\uD83C\uDDF7");
 
 		list.add(new TransportNetwork(context, NetworkId.PARIS)
 				         .setName(getString(R.string.np_name_paris))
@@ -495,7 +495,7 @@ public class TransportNetworks {
 		);
 
 		// New Zealand
-		region = getString(R.string.np_region_nz) + " \uD83C\uDDF3\uD83C\uDDFF";
+		region = region(getString(R.string.np_region_nz), "\uD83C\uDDF3\uD83C\uDDFF");
 
 		list.add(new TransportNetwork(context, NetworkId.NZ)
 				         .setDescription(getString(R.string.np_desc_nz))
@@ -504,7 +504,7 @@ public class TransportNetworks {
 		);
 
 		// Spain
-		region = getString(R.string.np_region_spain) + " \uD83C\uDDEA\uD83C\uDDF8";
+		region = region(getString(R.string.np_region_spain), "\uD83C\uDDEA\uD83C\uDDF8");
 
 		list.add(new TransportNetwork(context, NetworkId.SPAIN)
 				         .setName(getString(R.string.np_name_spain))
@@ -514,7 +514,7 @@ public class TransportNetworks {
 		);
 
 		// Brazil
-		region = getString(R.string.np_region_br) + " \uD83C\uDDE7\uD83C\uDDF7";
+		region = region(getString(R.string.np_region_br), "\uD83C\uDDE7\uD83C\uDDF7");
 
 		list.add(new TransportNetwork(context, NetworkId.BR)
 				.setName(getString(R.string.np_name_br))
@@ -532,7 +532,7 @@ public class TransportNetworks {
 		);
 
 		// Canada
-		region = getString(R.string.np_region_canada) + " \uD83C\uDDE8\uD83C\uDDE6";
+		region = region(getString(R.string.np_region_canada), "\uD83C\uDDE8\uD83C\uDDE6");
 
 		list.add(new TransportNetwork(context, NetworkId.ONTARIO)
 				.setName(context.getString(R.string.np_name_ontario))
@@ -591,5 +591,9 @@ public class TransportNetworks {
 
 	private String getString(int res) {
 		return context.getString(res);
+	}
+
+	private String region(String name, String flag) {
+		return name + " " + flag;
 	}
 }

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -48,7 +48,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.RT)
 				         .setName(getString(R.string.np_name_rt))
-				         .setDescription(getString(R.string.np_desc_rt))
+				         .setDescription(description(getString(R.string.np_desc_rt), getString(R.string.np_desc_rt_networks)))
 				         .setRegion(region(getString(R.string.np_region_europe), "\uD83C\uDDEA\uD83C\uDDFA"))
 		);
 
@@ -376,7 +376,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_italy), "\uD83C\uDDEE\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.IT)
-				.setDescription(getString(R.string.np_desc_it) + "\n(" + getString(R.string.np_desc_it_networks) + ")")
+				.setDescription(description(getString(R.string.np_desc_it), getString(R.string.np_desc_it_networks)))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
@@ -473,7 +473,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCESOUTHWEST)
 				.setName(getString(R.string.np_name_frenchsouthwest))
-				.setDescription(getString(R.string.np_desc_frenchsouthwest) + "\n(" + getString(R.string.np_desc_frenchsouthwest_networks) + ")")
+				.setDescription(description(getString(R.string.np_desc_frenchsouthwest), getString(R.string.np_desc_frenchsouthwest_networks)))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
@@ -481,7 +481,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHEAST)
 				.setName(getString(R.string.np_name_francenortheast))
-				.setDescription(getString(R.string.np_desc_francenortheast) + "\n(" + getString(R.string.np_desc_francenortheast_networks) + ")")
+				.setDescription(description(getString(R.string.np_desc_francenortheast), getString(R.string.np_desc_francenortheast_networks)))
 				.setRegion(region)
 				.setStatus(ALPHA)
 				.setGoodLineNames(true)
@@ -489,7 +489,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHWEST)
 				.setName(getString(R.string.np_name_francenorthwest))
-				.setDescription(getString(R.string.np_desc_francenorthwest) + "\n(" + getString(R.string.np_desc_francenorthwest_networks) + ")")
+				.setDescription(description(getString(R.string.np_desc_francenorthwest), getString(R.string.np_desc_francenorthwest_networks)))
 				.setRegion(region)
 				.setStatus(ALPHA)
 		);
@@ -595,5 +595,9 @@ public class TransportNetworks {
 
 	private String region(String name, String flag) {
 		return name + " " + flag;
+	}
+
+	private String description(String desc, String networks) {
+		return desc + "\n(" + networks + ")";
 	}
 }

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -254,9 +254,11 @@ public class TransportNetworks {
 		);
 
 		// Liechtenstein
+		region = getString(R.string.np_region_liechtenstein) + " \uD83C\uDDF1\uD83C\uDDEE";
+
 		list.add(new TransportNetwork(context, NetworkId.VAO)
 				         .setDescription(getString(R.string.np_desc_vmobil))
-				         .setRegion(getString(R.string.np_region_liechtenstein))
+				         .setRegion(region)
 		);
 
 		// Switzerland
@@ -281,34 +283,38 @@ public class TransportNetworks {
 		);
 
 		// Belgium
+		region = getString(R.string.np_region_belgium) + " \uD83C\uDDE7\uD83C\uDDEA";
 
 		list.add(new TransportNetwork(context, NetworkId.SNCB)
-				         .setRegion(getString(R.string.np_region_belgium))
+				         .setRegion(region)
 		);
 
 		// Luxembourg
+		region = getString(R.string.np_region_luxembourg) + " \uD83C\uDDF1\uD83C\uDDFA";
 
 		list.add(new TransportNetwork(context, NetworkId.LU)
-				         .setRegion(getString(R.string.np_region_luxembourg))
+				         .setRegion(region)
 		);
 
 		// Netherlands
+		region = getString(R.string.np_region_netherlands) + " \uD83C\uDDF3\uD83C\uDDF1";
 
 		list.add(new TransportNetwork(context, NetworkId.NS)
 				         .setDescription(getString(R.string.np_desc_ns))
-				         .setRegion(getString(R.string.np_region_netherlands))
+				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		// Denmark
+		region = getString(R.string.np_region_denmark) + " \uD83C\uDDE9\uD83C\uDDF0";
 
 		list.add(new TransportNetwork(context, NetworkId.DSB)
 				         .setDescription(getString(R.string.np_desc_dsb))
-				         .setRegion(getString(R.string.np_region_denmark))
+				         .setRegion(region)
 		);
 
 		// Sweden
-		region = getString(R.string.np_region_sweden);
+		region = getString(R.string.np_region_sweden) + " \uD83C\uDDF8\uD83C\uDDEA";
 
 		list.add(new TransportNetwork(context, NetworkId.SE)
 				         .setDescription(getString(R.string.np_desc_se))
@@ -324,22 +330,24 @@ public class TransportNetworks {
 		);
 */
 		// Norway
+		region = getString(R.string.np_region_norway) + " \uD83C\uDDF3\uD83C\uDDF4";
 
 		list.add(new TransportNetwork(context, NetworkId.NRI)
 				         .setDescription(getString(R.string.np_desc_nri))
-				         .setRegion(getString(R.string.np_region_norway))
+				         .setRegion(region)
 		);
 
 		// Finland
+		region = getString(R.string.np_region_finland) + " \uD83C\uDDEB\uD83C\uDDEE";
 
 		list.add(new TransportNetwork(context, NetworkId.HSL)
 				         .setDescription(getString(R.string.np_desc_hsl))
-				         .setRegion(getString(R.string.np_region_finland))
+				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		// Great Britain
-		region = getString(R.string.np_region_gb);
+		region = getString(R.string.np_region_gb) + " \uD83C\uDDEC\uD83C\uDDE7";
 
 		list.add(new TransportNetwork(context, NetworkId.TLEM)
 				         .setDescription(getString(R.string.np_desc_tlem))
@@ -352,7 +360,7 @@ public class TransportNetworks {
 		);
 
 		// Ireland
-		region = getString(R.string.np_region_ireland);
+		region = getString(R.string.np_region_ireland) + " \uD83C\uDDEE\uD83C\uDDEA";
 
 		list.add(new TransportNetwork(context, NetworkId.TFI)
 				         .setDescription(getString(R.string.np_desc_tfi))
@@ -365,7 +373,7 @@ public class TransportNetworks {
 		);
 */
 		// Italy
-		region = getString(R.string.np_region_italy);
+		region = getString(R.string.np_region_italy) + " \uD83C\uDDEE\uD83C\uDDF9";
 
 		list.add(new TransportNetwork(context, NetworkId.IT)
 				.setDescription(getString(R.string.np_desc_it) + "\n(" + getString(R.string.np_desc_it_networks) + ")")
@@ -381,22 +389,24 @@ public class TransportNetworks {
 		);
 
 		// Poland
+		region = getString(R.string.np_region_poland) + " \uD83C\uDDF5\uD83C\uDDF1";
 
 		list.add(new TransportNetwork(context, NetworkId.PL)
 				         .setDescription(getString(R.string.np_desc_pl))
-				         .setRegion(getString(R.string.np_region_poland))
+				         .setRegion(region)
 		);
 
 		// United Arabian Emirates
+		region = getString(R.string.np_region_uae) + " \uD83C\uDDE6\uD83C\uDDEA";
 
 		list.add(new TransportNetwork(context, NetworkId.DUB)
 				         .setDescription(getString(R.string.np_desc_dub))
-				         .setRegion(getString(R.string.np_region_uae))
+				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		// United States of America
-		region = getString(R.string.np_region_usa);
+		region = getString(R.string.np_region_usa) + " \uD83C\uDDFA\uD83C\uDDF8";
 
 		list.add(new TransportNetwork(context, NetworkId.SF)
 				         .setDescription(getString(R.string.np_desc_sf))
@@ -424,7 +434,7 @@ public class TransportNetworks {
 		);
 */
 		// Australia
-		region = getString(R.string.np_region_australia);
+		region = getString(R.string.np_region_australia) + " \uD83C\uDDE6\uD83C\uDDFA";
 
 		list.add(new TransportNetwork(context, NetworkId.SYDNEY)
 				         .setName(getString(R.string.np_name_sydney))
@@ -438,10 +448,11 @@ public class TransportNetworks {
 		);
 
 		// Israel
+		region = getString(R.string.np_region_israel) + " \uD83C\uDDEE\uD83C\uDDF1";
 
 		list.add(new TransportNetwork(context, NetworkId.JET)
 				         .setDescription(getString(R.string.np_desc_jet))
-				         .setRegion(getString(R.string.np_region_israel))
+				         .setRegion(region)
 		);
 
 		// France
@@ -484,19 +495,21 @@ public class TransportNetworks {
 		);
 
 		// New Zealand
+		region = getString(R.string.np_region_nz) + " \uD83C\uDDF3\uD83C\uDDFF";
 
 		list.add(new TransportNetwork(context, NetworkId.NZ)
 				         .setDescription(getString(R.string.np_desc_nz))
-				         .setRegion(getString(R.string.np_region_nz))
+				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		// Spain
+		region = getString(R.string.np_region_spain) + " \uD83C\uDDEA\uD83C\uDDF8";
 
 		list.add(new TransportNetwork(context, NetworkId.SPAIN)
 				         .setName(getString(R.string.np_name_spain))
 				         .setDescription(getString(R.string.np_desc_spain))
-				         .setRegion(getString(R.string.np_region_spain))
+				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
@@ -519,7 +532,7 @@ public class TransportNetworks {
 		);
 
 		// Canada
-		region = getString(R.string.np_region_canada);
+		region = getString(R.string.np_region_canada) + " \uD83C\uDDE8\uD83C\uDDE6";
 
 		list.add(new TransportNetwork(context, NetworkId.ONTARIO)
 				.setName(context.getString(R.string.np_name_ontario))

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -48,12 +48,12 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.RT)
 				         .setName(getString(R.string.np_name_rt))
-				         .setDescription(description(getString(R.string.np_desc_rt), getString(R.string.np_desc_rt_networks)))
-				         .setRegion(region(getString(R.string.np_region_europe), "\uD83C\uDDEA\uD83C\uDDFA"))
+				         .setDescription(description(R.string.np_desc_rt, R.string.np_desc_rt_networks))
+				         .setRegion(region(R.string.np_region_europe, "\uD83C\uDDEA\uD83C\uDDFA"))
 		);
 
 		// Germany
-		region = region(getString(R.string.np_region_germany), "\uD83C\uDDE9\uD83C\uDDEA");
+		region = region(R.string.np_region_germany, "\uD83C\uDDE9\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.DB)
 				         .setName(getString(R.string.np_name_db))
@@ -95,7 +95,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.VGN)
-				         .setDescription(description(getString(R.string.np_desc_vgn), getString(R.string.np_desc_vgn_networks)))
+				         .setDescription(description(R.string.np_desc_vgn, R.string.np_desc_vgn_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -219,7 +219,7 @@ public class TransportNetworks {
 		);
 
 		// Austria
-		region = region(getString(R.string.np_region_austria), "\uD83C\uDDE6\uD83C\uDDF9");
+		region = region(R.string.np_region_austria, "\uD83C\uDDE6\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.OEBB)
 				         .setName(getString(R.string.np_name_oebb))
@@ -261,7 +261,7 @@ public class TransportNetworks {
 		);
 
 		// Liechtenstein
-		region = region(getString(R.string.np_region_liechtenstein), "\uD83C\uDDF1\uD83C\uDDEE");
+		region = region(R.string.np_region_liechtenstein, "\uD83C\uDDF1\uD83C\uDDEE");
 
 		list.add(new TransportNetwork(context, NetworkId.VAO)
 				         .setDescription(getString(R.string.np_desc_vmobil))
@@ -269,7 +269,7 @@ public class TransportNetworks {
 		);
 
 		// Switzerland
-		region = region(getString(R.string.np_region_switzerland), "\uD83C\uDDE8\uD83C\uDDED");
+		region = region(R.string.np_region_switzerland, "\uD83C\uDDE8\uD83C\uDDED");
 
 		list.add(new TransportNetwork(context, NetworkId.SBB)
 				         .setName(getString(R.string.np_name_sbb))
@@ -292,7 +292,7 @@ public class TransportNetworks {
 		);
 
 		// Belgium
-		region = region(getString(R.string.np_region_belgium), "\uD83C\uDDE7\uD83C\uDDEA");
+		region = region(R.string.np_region_belgium, "\uD83C\uDDE7\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.SNCB)
 				         .setDescription(getString(R.string.np_desc_sncb))
@@ -300,16 +300,16 @@ public class TransportNetworks {
 		);
 
 		// Luxembourg
-		region = region(getString(R.string.np_region_luxembourg), "\uD83C\uDDF1\uD83C\uDDFA");
+		region = region(R.string.np_region_luxembourg, "\uD83C\uDDF1\uD83C\uDDFA");
 
 		list.add(new TransportNetwork(context, NetworkId.LU)
 				         .setName(getString(R.string.np_name_lu))
-				         .setDescription(description(getString(R.string.np_desc_lu), getString(R.string.np_desc_lu_networks)))
+				         .setDescription(description(R.string.np_desc_lu, R.string.np_desc_lu_networks))
 				         .setRegion(region)
 		);
 
 		// Netherlands
-		region = region(getString(R.string.np_region_netherlands), "\uD83C\uDDF3\uD83C\uDDF1");
+		region = region(R.string.np_region_netherlands, "\uD83C\uDDF3\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.NS)
 				         .setDescription(getString(R.string.np_desc_ns))
@@ -318,7 +318,7 @@ public class TransportNetworks {
 		);
 
 		// Denmark
-		region = region(getString(R.string.np_region_denmark), "\uD83C\uDDE9\uD83C\uDDF0");
+		region = region(R.string.np_region_denmark, "\uD83C\uDDE9\uD83C\uDDF0");
 
 		list.add(new TransportNetwork(context, NetworkId.DSB)
 				         .setDescription(getString(R.string.np_desc_dsb))
@@ -326,7 +326,7 @@ public class TransportNetworks {
 		);
 
 		// Sweden
-		region = region(getString(R.string.np_region_sweden), "\uD83C\uDDF8\uD83C\uDDEA");
+		region = region(R.string.np_region_sweden, "\uD83C\uDDF8\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.SE)
 				         .setDescription(getString(R.string.np_desc_se))
@@ -342,7 +342,7 @@ public class TransportNetworks {
 		);
 */
 		// Norway
-		region = region(getString(R.string.np_region_norway), "\uD83C\uDDF3\uD83C\uDDF4");
+		region = region(R.string.np_region_norway, "\uD83C\uDDF3\uD83C\uDDF4");
 
 		list.add(new TransportNetwork(context, NetworkId.NRI)
 				         .setDescription(getString(R.string.np_desc_nri))
@@ -350,7 +350,7 @@ public class TransportNetworks {
 		);
 
 		// Finland
-		region = region(getString(R.string.np_region_finland), "\uD83C\uDDEB\uD83C\uDDEE");
+		region = region(R.string.np_region_finland, "\uD83C\uDDEB\uD83C\uDDEE");
 
 		list.add(new TransportNetwork(context, NetworkId.HSL)
 				         .setDescription(getString(R.string.np_desc_hsl))
@@ -359,7 +359,7 @@ public class TransportNetworks {
 		);
 
 		// Great Britain
-		region = region(getString(R.string.np_region_gb), "\uD83C\uDDEC\uD83C\uDDE7");
+		region = region(R.string.np_region_gb, "\uD83C\uDDEC\uD83C\uDDE7");
 
 		list.add(new TransportNetwork(context, NetworkId.TLEM)
 				         .setDescription(getString(R.string.np_desc_tlem))
@@ -372,7 +372,7 @@ public class TransportNetworks {
 		);
 
 		// Ireland
-		region = region(getString(R.string.np_region_ireland), "\uD83C\uDDEE\uD83C\uDDEA");
+		region = region(R.string.np_region_ireland, "\uD83C\uDDEE\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.TFI)
 				         .setDescription(getString(R.string.np_desc_tfi))
@@ -385,11 +385,11 @@ public class TransportNetworks {
 		);
 */
 		// Italy
-		region = region(getString(R.string.np_region_italy), "\uD83C\uDDEE\uD83C\uDDF9");
+		region = region(R.string.np_region_italy, "\uD83C\uDDEE\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.IT)
 				.setName(getString(R.string.np_name_it))
-				.setDescription(description(getString(R.string.np_desc_it), getString(R.string.np_desc_it_networks)))
+				.setDescription(description(R.string.np_desc_it, R.string.np_desc_it_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
@@ -402,7 +402,7 @@ public class TransportNetworks {
 		);
 
 		// Poland
-		region = region(getString(R.string.np_region_poland), "\uD83C\uDDF5\uD83C\uDDF1");
+		region = region(R.string.np_region_poland, "\uD83C\uDDF5\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.PL)
 				         .setName(getString(R.string.np_name_pl))
@@ -411,7 +411,7 @@ public class TransportNetworks {
 		);
 
 		// United Arabian Emirates
-		region = region(getString(R.string.np_region_uae), "\uD83C\uDDE6\uD83C\uDDEA");
+		region = region(R.string.np_region_uae, "\uD83C\uDDE6\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.DUB)
 				         .setName(getString(R.string.np_name_dub))
@@ -421,7 +421,7 @@ public class TransportNetworks {
 		);
 
 		// United States of America
-		region = region(getString(R.string.np_region_usa), "\uD83C\uDDFA\uD83C\uDDF8");
+		region = region(R.string.np_region_usa, "\uD83C\uDDFA\uD83C\uDDF8");
 
 		list.add(new TransportNetwork(context, NetworkId.SF)
 				         .setName(getString(R.string.np_name_sf))
@@ -437,7 +437,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.RTACHICAGO)
 				.setName(getString(R.string.np_name_rtachicago))
-				.setDescription(description(getString(R.string.np_desc_rtachicago), getString(R.string.np_desc_rtachicago_networks)))
+				.setDescription(description(R.string.np_desc_rtachicago, R.string.np_desc_rtachicago_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 		);
@@ -450,7 +450,7 @@ public class TransportNetworks {
 		);
 */
 		// Australia
-		region = region(getString(R.string.np_region_australia), "\uD83C\uDDE6\uD83C\uDDFA");
+		region = region(R.string.np_region_australia, "\uD83C\uDDE6\uD83C\uDDFA");
 
 		list.add(new TransportNetwork(context, NetworkId.SYDNEY)
 				         .setName(getString(R.string.np_name_sydney))
@@ -465,7 +465,7 @@ public class TransportNetworks {
 		);
 
 /*		// Israel
-		region = region(getString(R.string.np_region_israel), "\uD83C\uDDEE\uD83C\uDDF1");
+		region = region(R.string.np_region_israel, "\uD83C\uDDEE\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.JET)
 				         .setDescription(getString(R.string.np_desc_jet))
@@ -473,11 +473,11 @@ public class TransportNetworks {
 		);
 */
 		// France
-		region = region(getString(R.string.np_region_france), "\uD83C\uDDEB\uD83C\uDDF7");
+		region = region(R.string.np_region_france, "\uD83C\uDDEB\uD83C\uDDF7");
 
 		list.add(new TransportNetwork(context, NetworkId.PARIS)
 				         .setName(getString(R.string.np_name_paris))
-				         .setDescription(description(getString(R.string.np_desc_paris), getString(R.string.np_desc_paris_networks)))
+				         .setDescription(description(R.string.np_desc_paris, R.string.np_desc_paris_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -490,7 +490,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCESOUTHWEST)
 				.setName(getString(R.string.np_name_frenchsouthwest))
-				.setDescription(description(getString(R.string.np_desc_frenchsouthwest), getString(R.string.np_desc_frenchsouthwest_networks)))
+				.setDescription(description(R.string.np_desc_frenchsouthwest, R.string.np_desc_frenchsouthwest_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
@@ -498,7 +498,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHEAST)
 				.setName(getString(R.string.np_name_francenortheast))
-				.setDescription(description(getString(R.string.np_desc_francenortheast), getString(R.string.np_desc_francenortheast_networks)))
+				.setDescription(description(R.string.np_desc_francenortheast, R.string.np_desc_francenortheast_networks))
 				.setRegion(region)
 				.setStatus(ALPHA)
 				.setGoodLineNames(true)
@@ -506,37 +506,37 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHWEST)
 				.setName(getString(R.string.np_name_francenorthwest))
-				.setDescription(description(getString(R.string.np_desc_francenorthwest), getString(R.string.np_desc_francenorthwest_networks)))
+				.setDescription(description(R.string.np_desc_francenorthwest, R.string.np_desc_francenorthwest_networks))
 				.setRegion(region)
 				.setStatus(ALPHA)
 		);
 
 		// New Zealand
-		region = region(getString(R.string.np_region_nz), "\uD83C\uDDF3\uD83C\uDDFF");
+		region = region(R.string.np_region_nz, "\uD83C\uDDF3\uD83C\uDDFF");
 
 		list.add(new TransportNetwork(context, NetworkId.NZ)
 				         .setName(getString(R.string.np_name_nz))
-				         .setDescription(description(getString(R.string.np_desc_nz), getString(R.string.np_desc_nz_networks)))
+				         .setDescription(description(R.string.np_desc_nz, R.string.np_desc_nz_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		// Spain
-		region = region(getString(R.string.np_region_spain), "\uD83C\uDDEA\uD83C\uDDF8");
+		region = region(R.string.np_region_spain, "\uD83C\uDDEA\uD83C\uDDF8");
 
 		list.add(new TransportNetwork(context, NetworkId.SPAIN)
 				         .setName(getString(R.string.np_name_spain))
-				         .setDescription(description(getString(R.string.np_desc_spain), getString(R.string.np_desc_spain_networks)))
+				         .setDescription(description(R.string.np_desc_spain, R.string.np_desc_spain_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		// Brazil
-		region = region(getString(R.string.np_region_br), "\uD83C\uDDE7\uD83C\uDDF7");
+		region = region(R.string.np_region_br, "\uD83C\uDDE7\uD83C\uDDF7");
 
 		list.add(new TransportNetwork(context, NetworkId.BR)
 				.setName(getString(R.string.np_name_br))
-				.setDescription(description(getString(R.string.np_desc_br), getString(R.string.np_desc_br_networks)))
+				.setDescription(description(R.string.np_desc_br, R.string.np_desc_br_networks))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)
@@ -550,18 +550,18 @@ public class TransportNetworks {
 		);
 
 		// Canada
-		region = region(getString(R.string.np_region_canada), "\uD83C\uDDE8\uD83C\uDDE6");
+		region = region(R.string.np_region_canada, "\uD83C\uDDE8\uD83C\uDDE6");
 
 		list.add(new TransportNetwork(context, NetworkId.ONTARIO)
 				.setName(getString(R.string.np_name_ontario))
-				.setDescription(description(getString(R.string.np_desc_ontario), getString(R.string.np_desc_ontario_networks)))
+				.setDescription(description(R.string.np_desc_ontario, R.string.np_desc_ontario_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
 		);
 		list.add(new TransportNetwork(context, NetworkId.QUEBEC)
 				.setName(getString(R.string.np_name_quebec))
-				.setDescription(description(getString(R.string.np_desc_quebec), getString(R.string.np_desc_quebec_networks)))
+				.setDescription(description(R.string.np_desc_quebec, R.string.np_desc_quebec_networks))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)
@@ -611,11 +611,11 @@ public class TransportNetworks {
 		return context.getString(res);
 	}
 
-	private String region(String name, String flag) {
+	private String region(int name, String flag) {
 		return flag + " " + name;
 	}
 
-	private String description(String desc, String networks) {
-		return desc + "\n(" + networks + ")";
+	private String description(int desc, int networks) {
+		return getString(desc) + "\n(" + getString(networks) + ")";
 	}
 }

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -49,7 +49,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.RT)
 				         .setName(getString(R.string.np_name_rt))
-				         .setDescription(description(R.string.np_desc_rt, R.string.np_desc_rt_networks))
+				         .setDescription(getString(R.string.np_desc_rt), getString(R.string.np_desc_rt_networks))
 				         .setRegion(region(R.string.np_region_europe, "\uD83C\uDDEA\uD83C\uDDFA"))
 		);
 
@@ -96,13 +96,12 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.VGN)
-				         .setDescription(description(R.string.np_desc_vgn, R.string.np_desc_vgn_networks))
+				         .setDescription(getString(R.string.np_desc_vgn), getString(R.string.np_desc_vgn_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.VVM)
-				         .setName(getString(R.string.np_name_vvm))
 				         .setDescription(getString(R.string.np_desc_vvm))
 				         .setRegion(region)
 		);
@@ -305,7 +304,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.LU)
 				         .setName(getString(R.string.np_name_lu))
-				         .setDescription(description(R.string.np_desc_lu, R.string.np_desc_lu_networks))
+				         .setDescription(getString(R.string.np_desc_lu), getString(R.string.np_desc_lu_networks))
 				         .setRegion(region)
 		);
 
@@ -334,14 +333,6 @@ public class TransportNetworks {
 				         .setRegion(region)
 		);
 
-		// See https://github.com/grote/Transportr/issues/175
-/*		list.add(new TransportNetwork(context, NetworkId.STOCKHOLM)
-				         .setName(getString(R.string.np_name_stockholm))
-				         .setDescription(getString(R.string.np_desc_stockholm))
-				         .setRegion(region)
-				         .setStatus(TransportNetwork.Status.BETA)
-		);
-*/
 		// Norway
 		region = region(R.string.np_region_norway, "\uD83C\uDDF3\uD83C\uDDF4");
 
@@ -390,7 +381,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.IT)
 				.setName(getString(R.string.np_name_it))
-				.setDescription(description(R.string.np_desc_it, R.string.np_desc_it_networks))
+				.setDescription(getString(R.string.np_desc_it), getString(R.string.np_desc_it_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
@@ -438,7 +429,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.RTACHICAGO)
 				.setName(getString(R.string.np_name_rtachicago))
-				.setDescription(description(R.string.np_desc_rtachicago, R.string.np_desc_rtachicago_networks))
+				.setDescription(getString(R.string.np_desc_rtachicago), getString(R.string.np_desc_rtachicago_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 		);
@@ -478,7 +469,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.PARIS)
 				         .setName(getString(R.string.np_name_paris))
-				         .setDescription(description(R.string.np_desc_paris, R.string.np_desc_paris_networks))
+				         .setDescription(getString(R.string.np_desc_paris), getString(R.string.np_desc_paris_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -491,7 +482,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCESOUTHWEST)
 				.setName(getString(R.string.np_name_frenchsouthwest))
-				.setDescription(description(R.string.np_desc_frenchsouthwest, R.string.np_desc_frenchsouthwest_networks))
+				.setDescription(getString(R.string.np_desc_frenchsouthwest), getString(R.string.np_desc_frenchsouthwest_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
@@ -499,7 +490,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHEAST)
 				.setName(getString(R.string.np_name_francenortheast))
-				.setDescription(description(R.string.np_desc_francenortheast, R.string.np_desc_francenortheast_networks))
+				.setDescription(getString(R.string.np_desc_francenortheast), getString(R.string.np_desc_francenortheast_networks))
 				.setRegion(region)
 				.setStatus(ALPHA)
 				.setGoodLineNames(true)
@@ -507,7 +498,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.FRANCENORTHWEST)
 				.setName(getString(R.string.np_name_francenorthwest))
-				.setDescription(description(R.string.np_desc_francenorthwest, R.string.np_desc_francenorthwest_networks))
+				.setDescription(getString(R.string.np_desc_francenorthwest), getString(R.string.np_desc_francenorthwest_networks))
 				.setRegion(region)
 				.setStatus(ALPHA)
 		);
@@ -517,7 +508,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.NZ)
 				         .setName(getString(R.string.np_name_nz))
-				         .setDescription(description(R.string.np_desc_nz, R.string.np_desc_nz_networks))
+				         .setDescription(getString(R.string.np_desc_nz), getString(R.string.np_desc_nz_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -527,7 +518,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.SPAIN)
 				         .setName(getString(R.string.np_name_spain))
-				         .setDescription(description(R.string.np_desc_spain, R.string.np_desc_spain_networks))
+				         .setDescription(getString(R.string.np_desc_spain), getString(R.string.np_desc_spain_networks))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -537,7 +528,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.BR)
 				.setName(getString(R.string.np_name_br))
-				.setDescription(description(R.string.np_desc_br, R.string.np_desc_br_networks))
+				.setDescription(getString(R.string.np_desc_br), getString(R.string.np_desc_br_networks))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)
@@ -555,14 +546,14 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.ONTARIO)
 				.setName(getString(R.string.np_name_ontario))
-				.setDescription(description(R.string.np_desc_ontario, R.string.np_desc_ontario_networks))
+				.setDescription(getString(R.string.np_desc_ontario), getString(R.string.np_desc_ontario_networks))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
 		);
 		list.add(new TransportNetwork(context, NetworkId.QUEBEC)
 				.setName(getString(R.string.np_name_quebec))
-				.setDescription(description(R.string.np_desc_quebec, R.string.np_desc_quebec_networks))
+				.setDescription(getString(R.string.np_desc_quebec), getString(R.string.np_desc_quebec_networks))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)
@@ -614,9 +605,5 @@ public class TransportNetworks {
 
 	private String region(@StringRes int name, String flag) {
 		return flag + " " + getString(name);
-	}
-
-	private String description(@StringRes int desc, @StringRes int networks) {
-		return getString(desc) + "\n(" + getString(networks) + ")";
 	}
 }

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -18,6 +18,7 @@
 package de.grobox.liberario;
 
 import android.content.Context;
+import android.support.annotation.StringRes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -611,11 +612,11 @@ public class TransportNetworks {
 		return context.getString(res);
 	}
 
-	private String region(int name, String flag) {
-		return flag + " " + name;
+	private String region(@StringRes int name, String flag) {
+		return flag + " " + getString(name);
 	}
 
-	private String description(int desc, int networks) {
+	private String description(@StringRes int desc, @StringRes int networks) {
 		return getString(desc) + "\n(" + getString(networks) + ")";
 	}
 }

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -95,12 +95,13 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.VGN)
-				         .setDescription(getString(R.string.np_desc_vgn))
+				         .setDescription(description(getString(R.string.np_desc_vgn), getString(R.string.np_desc_vgn_networks)))
 				         .setRegion(region)
-						 .setStatus(BETA)
+				         .setStatus(BETA)
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.VVM)
+				         .setName(getString(R.string.np_name_vvm))
 				         .setDescription(getString(R.string.np_desc_vvm))
 				         .setRegion(region)
 		);
@@ -126,6 +127,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.BSVAG)
+				         .setName(getString(R.string.np_name_bsvag))
 				         .setDescription(getString(R.string.np_desc_bsvag))
 				         .setRegion(region)
 		);
@@ -148,6 +150,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.NASA)
+				         .setName(getString(R.string.np_name_nasa))
 				         .setDescription(getString(R.string.np_desc_nasa))
 				         .setRegion(region)
 				         .setStatus(BETA)
@@ -164,7 +167,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.NVV)
-				         .setName("NVV/RMV")
+				         .setName(getString(R.string.np_name_nvv))
 				         .setDescription(getString(R.string.np_desc_nvv))
 				         .setRegion(region)
 		);
@@ -190,6 +193,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.VAGFR)
+				         .setName(getString(R.string.np_name_vagfr))
 				         .setDescription(getString(R.string.np_desc_vagfr))
 				         .setRegion(region)
 		);
@@ -218,6 +222,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_austria), "\uD83C\uDDE6\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.OEBB)
+				         .setName(getString(R.string.np_name_oebb))
 				         .setDescription(getString(R.string.np_desc_oebb))
 				         .setRegion(region)
 		);
@@ -228,6 +233,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.LINZ)
+				         .setName(getString(R.string.np_name_linz))
 				         .setDescription(getString(R.string.np_desc_linz))
 				         .setRegion(region)
 		);
@@ -243,6 +249,7 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.STV)
+				         .setName(getString(R.string.np_name_stv))
 				         .setDescription(getString(R.string.np_desc_stv))
 				         .setRegion(region)
 		);
@@ -265,6 +272,8 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_switzerland), "\uD83C\uDDE8\uD83C\uDDED");
 
 		list.add(new TransportNetwork(context, NetworkId.SBB)
+				         .setName(getString(R.string.np_name_sbb))
+				         .setDescription(getString(R.string.np_desc_sbb))
 				         .setRegion(region)
 		);
 
@@ -286,6 +295,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_belgium), "\uD83C\uDDE7\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.SNCB)
+				         .setDescription(getString(R.string.np_desc_sncb))
 				         .setRegion(region)
 		);
 
@@ -293,6 +303,8 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_luxembourg), "\uD83C\uDDF1\uD83C\uDDFA");
 
 		list.add(new TransportNetwork(context, NetworkId.LU)
+				         .setName(getString(R.string.np_name_lu))
+				         .setDescription(description(getString(R.string.np_desc_lu), getString(R.string.np_desc_lu_networks)))
 				         .setRegion(region)
 		);
 
@@ -376,6 +388,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_italy), "\uD83C\uDDEE\uD83C\uDDF9");
 
 		list.add(new TransportNetwork(context, NetworkId.IT)
+				.setName(getString(R.string.np_name_it))
 				.setDescription(description(getString(R.string.np_desc_it), getString(R.string.np_desc_it_networks)))
 				.setRegion(region)
 				.setStatus(BETA)
@@ -392,6 +405,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_poland), "\uD83C\uDDF5\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.PL)
+				         .setName(getString(R.string.np_name_pl))
 				         .setDescription(getString(R.string.np_desc_pl))
 				         .setRegion(region)
 		);
@@ -400,6 +414,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_uae), "\uD83C\uDDE6\uD83C\uDDEA");
 
 		list.add(new TransportNetwork(context, NetworkId.DUB)
+				         .setName(getString(R.string.np_name_dub))
 				         .setDescription(getString(R.string.np_desc_dub))
 				         .setRegion(region)
 				         .setStatus(BETA)
@@ -409,6 +424,7 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_usa), "\uD83C\uDDFA\uD83C\uDDF8");
 
 		list.add(new TransportNetwork(context, NetworkId.SF)
+				         .setName(getString(R.string.np_name_sf))
 				         .setDescription(getString(R.string.np_desc_sf))
 				         .setRegion(region)
 		);
@@ -421,7 +437,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.RTACHICAGO)
 				.setName(getString(R.string.np_name_rtachicago))
-				.setDescription(getString(R.string.np_name_rtachicago))
+				.setDescription(description(getString(R.string.np_desc_rtachicago), getString(R.string.np_desc_rtachicago_networks)))
 				.setRegion(region)
 				.setStatus(BETA)
 		);
@@ -443,24 +459,25 @@ public class TransportNetworks {
 		);
 
 		list.add(new TransportNetwork(context, NetworkId.MET)
+				         .setName(getString(R.string.np_name_met))
 				         .setDescription(getString(R.string.np_desc_met))
 				         .setRegion(region)
 		);
 
-		// Israel
+/*		// Israel
 		region = region(getString(R.string.np_region_israel), "\uD83C\uDDEE\uD83C\uDDF1");
 
 		list.add(new TransportNetwork(context, NetworkId.JET)
 				         .setDescription(getString(R.string.np_desc_jet))
 				         .setRegion(region)
 		);
-
+*/
 		// France
 		region = region(getString(R.string.np_region_france), "\uD83C\uDDEB\uD83C\uDDF7");
 
 		list.add(new TransportNetwork(context, NetworkId.PARIS)
 				         .setName(getString(R.string.np_name_paris))
-				         .setDescription(getString(R.string.np_desc_paris))
+				         .setDescription(description(getString(R.string.np_desc_paris), getString(R.string.np_desc_paris_networks)))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -498,7 +515,8 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_nz), "\uD83C\uDDF3\uD83C\uDDFF");
 
 		list.add(new TransportNetwork(context, NetworkId.NZ)
-				         .setDescription(getString(R.string.np_desc_nz))
+				         .setName(getString(R.string.np_name_nz))
+				         .setDescription(description(getString(R.string.np_desc_nz), getString(R.string.np_desc_nz_networks)))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -508,7 +526,7 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.SPAIN)
 				         .setName(getString(R.string.np_name_spain))
-				         .setDescription(getString(R.string.np_desc_spain))
+				         .setDescription(description(getString(R.string.np_desc_spain), getString(R.string.np_desc_spain_networks)))
 				         .setRegion(region)
 				         .setStatus(BETA)
 		);
@@ -518,14 +536,14 @@ public class TransportNetworks {
 
 		list.add(new TransportNetwork(context, NetworkId.BR)
 				.setName(getString(R.string.np_name_br))
-				.setDescription(getString(R.string.np_desc_br))
+				.setDescription(description(getString(R.string.np_desc_br), getString(R.string.np_desc_br_networks)))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)
 		);
 		list.add(new TransportNetwork(context, NetworkId.BRFLORIPA)
-				.setName(context.getString(R.string.np_name_br_floripa))
-				.setDescription(context.getString(R.string.np_desc_br_floripa))
+				.setName(getString(R.string.np_name_br_floripa))
+				.setDescription(getString(R.string.np_desc_br_floripa))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)
@@ -535,15 +553,15 @@ public class TransportNetworks {
 		region = region(getString(R.string.np_region_canada), "\uD83C\uDDE8\uD83C\uDDE6");
 
 		list.add(new TransportNetwork(context, NetworkId.ONTARIO)
-				.setName(context.getString(R.string.np_name_ontario))
-				.setDescription(context.getString(R.string.np_desc_ontario))
+				.setName(getString(R.string.np_name_ontario))
+				.setDescription(description(getString(R.string.np_desc_ontario), getString(R.string.np_desc_ontario_networks)))
 				.setRegion(region)
 				.setStatus(BETA)
 				.setGoodLineNames(true)
 		);
 		list.add(new TransportNetwork(context, NetworkId.QUEBEC)
-				.setName(context.getString(R.string.np_name_quebec))
-				.setDescription(context.getString(R.string.np_desc_quebec))
+				.setName(getString(R.string.np_name_quebec))
+				.setDescription(description(getString(R.string.np_desc_quebec), getString(R.string.np_desc_quebec_networks)))
 				.setRegion(region)
 				.setStatus(TransportNetwork.Status.ALPHA)
 				.setGoodLineNames(true)

--- a/src/de/grobox/liberario/TransportNetworks.java
+++ b/src/de/grobox/liberario/TransportNetworks.java
@@ -594,7 +594,7 @@ public class TransportNetworks {
 	}
 
 	private String region(String name, String flag) {
-		return name + " " + flag;
+		return flag + " " + name;
 	}
 
 	private String description(String desc, String networks) {


### PR DESCRIPTION
 * I added emoji-flags to every region.
 * I moved the flags before the names of the regions. Downturn of this is that the sorting is now different. Benefit is that it looks cleaner imho.
 * I introduced helper-functions for the structuring of the strings
 * I sorted the string-xml
 * I reviewed every provider and tried to update/improve it and correct data where necessary.
 * I deactivated Israel since it seems to be broken.
 * I put all strings into the xml, because I felt it is cleaner this way.

This should also be relevant to #234, but it does not introduce a string for every network, (I used strings only where the name differed from the network name. If you want to I can also add strings for those cases.)

From my standpoint this can be merged, however I am also open for discussion. If anything should be changed I can rebase my PR.

Apart from that, I fear this will mess with transifex. I made some strings that where translatable (and still have translations) non-translatable and swapped one or two strings (name with desc). I did not touch the translated string-files since I do not know the translation-workflow.