### PR TITLE
prevent locations of type ANY to enter the favorites

### DIFF
--- a/src/de/grobox/liberario/data/RecentsDB.java
+++ b/src/de/grobox/liberario/data/RecentsDB.java
@@ -96,8 +96,8 @@ public class RecentsDB {
 	}
 
 	public static void updateFavLocation(Context context, Location loc, FavLocation.LOC_TYPE loc_type) {
-		if(loc == null || loc.type == LocationType.COORD) {
-			// don't store GPS locations
+		if(loc == null || loc.type == LocationType.COORD || loc.type == LocationType.ANY) {
+			// don't store GPS or ANY locations
 			return;
 		}
 


### PR DESCRIPTION
In #251 an error occured due to a Location of Type `ANY` entering the database through a malformed intent. This patch prevents this from happening. (I tested that these malformed locations did not appear in the favorites.)

Closes #251.