### PR TITLE
Update description Spain

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -335,8 +335,8 @@ there are any).</string>
 
     <string name="np_region_spain">Spain</string>
     <string name="np_name_spain">Spain</string>
-    <string name="np_desc_spain">Spain, Euskadi, Madrid, Barcelona</string>
-    <string name="np_desc_spain_networks" translatable="false">EMT, TMB, Moveuskadi, Renfe, Lurraldebus</string>
+    <string name="np_desc_spain">Madrid, Barcelona, Euskadi-Basque Country, Valencia, Alicante, Mallorca, Menorca, Tenerife, La Palma</string>
+    <string name="np_desc_spain_networks" translatable="false">CRTM, TMB, FGC, Moveuskadi, Renfe, Lurraldebus, Metrovalencia, EMT, TRAM, CTM, CIME, Tranvía, TITSA, TILP</string>
 
     <string name="np_region_sweden">Sweden</string>
     <string name="np_desc_se">Sweden, Stockholm</string>


### PR DESCRIPTION
I updated the description and removed Spain form it, as the renfe data available only works in Basque Country