### PR TITLE
Update SBB info

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -344,7 +344,7 @@ there are any).</string>
     <string name="np_region_switzerland">Switzerland</string>
     <!-- SBB is german/international, CFF is french and FFS is italian! So this IS translatable. -->
     <string name="np_name_sbb" translatable="true">SBB</string>
-    <string name="np_desc_sbb">Trains in Switzerland</string>
+    <string name="np_desc_sbb">Switzerland</string>
     <string name="np_desc_vbl">Luzern</string>
     <string name="np_desc_zvv">Zurich</string>
 


### PR DESCRIPTION
Idea: change "Trains in Switzerland" to "Switzerland", as the SBB data contains basically all public transport info for Switzerland. The OEBB data is also described as Austria (not "Trains in Austria") because there is more information available.