### PR TITLE
Try to fix failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: android
 before_script: ./pre-build.sh && sed -i "s#com.android.tools.build:gradle:.*'#com.android.tools.build:gradle:1.5.0'#" build.gradle
 jdk: openjdk7
+before_cache:
+    - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+    - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+    directories:
+        - $HOME/.gradle/caches/
 android:
   components:
     - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+sudo: true # travis-ci/travis-ci#5582 implies this could help against killed build-jobs
 before_script: ./pre-build.sh && sed -i "s#com.android.tools.build:gradle:.*'#com.android.tools.build:gradle:1.5.0'#" build.gradle
 jdk: openjdk7
 before_cache:


### PR DESCRIPTION
I noticed that travis sometimes fails with a killed process.
I found some hints that this might not be the case when `sudo:true` is set. As far as I could test it (I started the build during different daytimes) this seems to solve the sporadic failures.

Moreover I enabled caching of dependencies and build for both `oraclejdk7`, `oraclejdk8` and `openjdk7`.
Those last two are just optional, I can also remove them.
The downturn of `sudo:true` is that it takes a bit longer to start up the machine.