### PR TITLE
Use all available width for leg message

### DIFF
--- a/res/layout/leg_details.xml
+++ b/res/layout/leg_details.xml
@@ -60,8 +60,7 @@
         android:textSize="12sp"
         tools:text="This is an important message for this trip. It may contain a lot of text."
         android:layout_below="@+id/lineView"
-        android:layout_alignRight="@+id/lineView"
-        android:layout_alignEnd="@+id/lineView"
+        android:layout_toLeftOf="@+id/durationView"
         android:layout_marginTop="10dp"/>
 
 </RelativeLayout>


### PR DESCRIPTION
I don't know if this is the best way to fix this, but it seems to work without breaking anything.

Before:
<img src="https://cloud.githubusercontent.com/assets/5279601/21770092/0cfd9f06-d682-11e6-9f16-8760f91acfe8.png" width="325"> 

After:
<img src="https://cloud.githubusercontent.com/assets/5279601/21770093/0cfe4780-d682-11e6-8554-cb81704ac36a.png" width="325"> <img src="https://cloud.githubusercontent.com/assets/5279601/21770091/0ce26eb6-d682-11e6-9656-2888998b0c98.png" width="325">
