### PR TITLE
do not show homescreen after first shortcut installation

### DIFF
--- a/src/de/grobox/liberario/Preferences.java
+++ b/src/de/grobox/liberario/Preferences.java
@@ -41,6 +41,7 @@ public class Preferences {
 	private final static String OPTIMIZE = "pref_key_optimize";
 	private final static String EXIT_ON_BACK = "pref_key_exit_app_on_back_press";
 	private final static String SELECTED_PRODUCTS = "_selected_products";
+	public final static String SHORTCUT_QUICKHOME_INSTALLED = "pref_shortcut_quickhome_installed";
 
 	private static String getNetwork(Context context, int i) {
 		SharedPreferences settings = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);

--- a/src/de/grobox/liberario/fragments/SettingsFragment.java
+++ b/src/de/grobox/liberario/fragments/SettingsFragment.java
@@ -108,11 +108,17 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
 				addIntent.setAction("com.android.launcher.action.INSTALL_SHORTCUT");
 				getContext().sendBroadcast(addIntent);
 
-				// switch to home-screen to let the user see the new shortcut
-				Intent startMain = new Intent(Intent.ACTION_MAIN);
-				startMain.addCategory(Intent.CATEGORY_HOME);
-				startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-				startActivity(startMain);
+				// switch to home-screen to let the user see the new shortcut if this is the first
+				// time installing
+				if(!Preferences.getPref(getContext(), Preferences.SHORTCUT_QUICKHOME_INSTALLED, false)) {
+					Intent startMain = new Intent(Intent.ACTION_MAIN);
+					startMain.addCategory(Intent.CATEGORY_HOME);
+					startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+					startActivity(startMain);
+				}
+
+				// remember installation for subsequent installation-attempts
+				Preferences.setPref(getContext(), Preferences.SHORTCUT_QUICKHOME_INSTALLED, true);
 
 				return true;
 			}


### PR DESCRIPTION
We cannot now which shortcuts are on the users homescreen. We can just generate intents for install and uninstall.
So the only other option for the case that the shortcut is already installed is storing whether we already did install it. If the user however uninstalls the shortcut we won't take notice. So we can only disable the switching the homescreen.