### PR TITLE
fix NearbyStationsFragment when using GPS

### DIFF
--- a/src/de/grobox/liberario/fragments/NearbyStationsFragment.java
+++ b/src/de/grobox/liberario/fragments/NearbyStationsFragment.java
@@ -107,9 +107,7 @@ public class NearbyStationsFragment extends TransportrFragment {
 			}
 
 			@Override
-			public void deactivateGPS() {
-				ui.stations_area.setVisibility(GONE);
-			}
+			public void deactivateGPS() { }
 
 			@Override
 			public void onLocationChanged(Location location) {


### PR DESCRIPTION
fixes #314

This uses the fix by @RunasSudo to show the results of a GPS-based
search in NearbyStationsFragment.

I messed a bit around with changing orientation, restarting the app, changing fragments and could not see any degradation.