### PR TITLE
Please rename region 'Africa' to 'Ghana' to keep consistency

### DIFF
--- a/app/src/main/java/de/grobox/transportr/networks/Region.java
+++ b/app/src/main/java/de/grobox/transportr/networks/Region.java
@@ -55,7 +55,7 @@ enum Region {
 	BRAZIL(R.string.np_region_br, "🇧🇷"),
 	CANADA(R.string.np_region_canada, "🇨🇦"),
 	COSTA_RICA(R.string.np_region_costa_rica, "🇨🇷"),
-	AFRICA(R.string.np_region_africa, "🌍");
+	GHANA(R.string.np_region_ghana, "🇬🇭");
 
 	private final @StringRes int name;
 	private final @Nullable String flag;

--- a/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.java
+++ b/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.java
@@ -630,7 +630,7 @@ public interface TransportNetworks {
 					.setId(NetworkId.GHANA)
 					.setName(R.string.np_name_ghana)
 					.setDescription(R.string.np_desc_ghana)
-					.setRegion(Region.AFRICA)
+					.setRegion(Region.GHANA)
 					.setStatus(ALPHA)
 					.setGoodLineNames(true)
 					.build(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,7 +369,7 @@ there are any).</string>
 	<string name="np_desc_costa_rica" translatable="false">Tren Urbano</string>
 	<string name="np_desc_costa_rica_networks" translatable="false">INCOFER</string>
 
-	<string name="np_region_africa">Africa</string>
+	<string name="np_region_ghana">Ghana</string>
 	<string name="np_name_ghana">Ghana</string>
 	<string name="np_desc_ghana">Accra</string>
 


### PR DESCRIPTION
As [commented on the commit](https://github.com/grote/Transportr/commit/a5123191f8b5a323b708949a87b275483d1ac1c3#r26095681), I think it's much better to always use country names as regions (if it doesn't contain cross-border networks) instead of continent names.

As in the cases of Belgium, Italia and Spain, it would be a region called `Ghana` with one network called `Ghana`, too.