### PR TITLE
Update Ontario strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,8 +213,8 @@ there are any).</string>
 
 	<string name="np_region_canada">Canada</string>
 	<string name="np_name_ontario">Ontario</string>
-	<string name="np_desc_ontario">Ontario, Ottawa, Toronto</string>
-	<string name="np_desc_ontario_networks" translatable="false">Toronto Transit Commission - TTC, OC Transpo</string>
+	<string name="np_desc_ontario">Ontario, Ottawa, Toronto, Mississauga, Waterloo Region</string>
+	<string name="np_desc_ontario_networks" translatable="false">GO Transit, OC Transpo, Toronto Transit Commission - TTC, MiWay, Grand River Transit - GRT</string>
 	<string name="np_name_quebec">Quebec</string>
 	<string name="np_desc_quebec">Deux-Montagnes, Laval, L\'Assomption, Outaouais, Sud-Ouest, Quebec, Haut-Saint-Laurent, Lanaudière, La Presqu\'Île, Laurentides, Montreal, Les Moulins, Vallée du Richelieu, Chambly-Richelieu-Carignan, Roussillon, Sorel-Varennes, Le Richelain, Sherbrooke, Sainte-Julie</string>
 	<string name="np_desc_quebec_networks" translatable="false">AMT, STM, STL</string>


### PR DESCRIPTION
With the new support for some Ontario public transit agencies added recently in Navitia, [0] Transportr already supports these locations.

[0] https://groups.google.com/forum/#!topic/navitia/hByDZkChCjc/discussion