### PR TITLE
Bugfix: Prevent Product icon color blinking

### DIFF
--- a/app/src/main/java/de/grobox/transportr/ui/LineView.kt
+++ b/app/src/main/java/de/grobox/transportr/ui/LineView.kt
@@ -67,7 +67,7 @@ class LineView(context: Context, attr: AttributeSet?) : AppCompatTextView(contex
 
     private fun setDrawable(@DrawableRes res: Int, @ColorInt color: Int?) {
         val drawable = getDrawable(context, res)!!
-        if (color != null) drawable.setColorFilter(color, SRC_IN)
+        if (color != null) drawable.mutate().setColorFilter(color, SRC_IN)
         setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
     }
 


### PR DESCRIPTION
Currently, all `drawables` of the same product type e.g. in the departures list share the same common state, so when there are different foreground colors, scrolling through the list results in some ugly product icon color changing.

See these screenshots below: The first and second screenshot from the left show the same list, just scrolled a little bit. Note that on the left all bus icons are white (including the `1` one, which should be black), whereas in the middle all bus icons changed to black color.
![fix-product-color](https://user-images.githubusercontent.com/18088991/37049516-ad0630f8-2136-11e8-93b1-e3cab726028e.png)

This PR fixes this bug, the screenshot on the right was taken after the code change.

See [here](https://developer.android.com/reference/android/graphics/drawable/Drawable.html#mutate()) for more information.