### PR TITLE
Added Hungary provider

### DIFF
--- a/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
+++ b/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
@@ -530,6 +530,19 @@ private val networks = arrayOf(
                         factory = { SpainProvider(NAVITIA) }
                     )
                 )
+            ),
+            Country(
+                R.string.np_name_hungary, flag = "🇭🇺", networks = listOf(
+                    TransportNetwork(
+                        id = NetworkId.HUNGARY,
+                        name = R.string.np_name_hungary,
+                        description = R.string.np_desc_hungary,
+                        agencies = R.string.np_desc_hungary_networks,
+                        logo = R.drawable.network_hungary_logo,
+                        status = BETA,
+                        factory = { HungaryProvider(NAVITIA) }
+                    )
+                )
             )
         )
     ),

--- a/app/src/main/res/drawable/network_hungary_logo.xml
+++ b/app/src/main/res/drawable/network_hungary_logo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:viewportWidth="6"
+    android:viewportHeight="3"
+    android:width="64dp"
+    android:height="64dp">
+    <path
+        android:pathData="M0 0L6 0 6 3 0 3Z"
+        android:fillColor="#436f4d" />
+    <path
+        android:pathData="M0 0L6 0 6 2 0 2Z"
+        android:fillColor="#ffffff" />
+    <path
+        android:pathData="M0 0L6 0 6 1 0 1Z"
+        android:fillColor="#cd2a3e" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,6 +374,10 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="np_desc_spain">Madrid, Barcelona, Basque Country, Valencia, Alicante, Mallorca, Menorca, Tenerife, La Palma, Navarra</string>
 	<string name="np_desc_spain_networks" translatable="false">CRTM, TMB, FGC, Moveuskadi, Metrovalencia, EMT Valencia, TRAM, CTM, EMT Palma, CIME, Tranvía, TITSA, TILP, Transporte Interurbano de Navarra</string>
 
+	<string name="np_name_hungary">Hungary</string>
+	<string name="np_desc_hungary">Budapest, Miskolc</string>
+	<string name="np_desc_hungary_networks" translatable="false">BKK, MKV</string>
+
 	<string name="np_region_sweden">Sweden</string>
 	<string name="np_desc_se">Sweden, Stockholm</string>
 

--- a/artwork/networks/network_hungary_logo.svg
+++ b/artwork/networks/network_hungary_logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 6 3">
+<rect fill="#436F4D" width="6" height="3"/>
+<rect fill="#FFF" width="6" height="2"/>
+<rect fill="#CD2A3E" width="6" height="1"/>
+</svg>


### PR DESCRIPTION
Hi @grote 
This PR added Hungary provider, included two cities: Budapest (capital city) and Miskolc.
Related PR: https://github.com/schildbach/public-transport-enabler/pull/195