### PR TITLE
Adapt to the updated HslProvider which now uses Navitia

### DIFF
--- a/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
+++ b/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
@@ -407,11 +407,11 @@ private val networks = arrayOf(
             Country(
                 R.string.np_region_finland, flag = "🇫🇮", networks = listOf(
                     TransportNetwork(
-                        id = NetworkId.HSL,
+                        id = NetworkId.FI,
                         description = R.string.np_desc_hsl,
                         logo = R.drawable.network_hsl_logo,
                         status = BETA,
-                        factory = { HslProvider("pte_hsl", "Eixaeb9tnohcah7A") }
+                        factory = { HslProvider(NAVITIA) }
                     )
                 )
             ),


### PR DESCRIPTION
Related issue: #476 

----

Note that this requires https://github.com/schildbach/public-transport-enabler/pull/208 to be merged first.

Also, if I understand correctly, I'll have to update the PR later to bump the version of `public-transport-enabler` used in order to make the CI pass, right?