### PR TITLE
Show that HslProvider covers many parts of Finland

### DIFF
--- a/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
+++ b/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
@@ -408,8 +408,10 @@ private val networks = arrayOf(
                 R.string.np_region_finland, flag = "🇫🇮", networks = listOf(
                     TransportNetwork(
                         id = NetworkId.FI,
-                        description = R.string.np_desc_hsl,
-                        logo = R.drawable.network_hsl_logo,
+                        name = R.string.np_region_finland,
+                        description = R.string.np_desc_fi,
+                        agencies = R.string.np_desc_fi_networks,
+                        logo = R.drawable.network_fi_logo,
                         status = BETA,
                         factory = { HslProvider(NAVITIA) }
                     )

--- a/app/src/main/res/drawable/network_fi_logo.xml
+++ b/app/src/main/res/drawable/network_fi_logo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+
+    <path
+        android:fillColor="#ffffff"
+        android:strokeWidth="26.12788963"
+        android:pathData="M 0 0 H 64 V 64 H 0 V 0 Z" />
+    <path
+        android:fillColor="#003580"
+        android:fillType="evenOdd"
+        android:strokeWidth="1.00157475"
+        android:strokeLineJoin="round"
+        android:strokeLineCap="round"
+        android:pathData="M 17 0 L 17 23 L 0 23 L 0 41 L 17 41 L 17 64 L 35 64 L 35 41 L 64 41 L 64 23 L 35 23 L 35 0 L 17 0 z" />
+</vector>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -228,7 +228,6 @@ i sempre saber on ets per no perdre on baixar de l\'autobús. ]]></string>
   <string name="np_desc_rt">Només trens de llarga distància</string>
   <string name="np_desc_rt_networks">Aliança Railteam</string>
   <string name="np_region_finland">Finlàndia</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">França</string>
   <string name="np_name_francenortheast">França (nordest)</string>
   <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -224,7 +224,6 @@ und weiß immer, wo man aussteigen muss.
   <string name="np_desc_rt">Nur Fernzüge</string>
   <string name="np_desc_rt_networks">Railteam-Allianz</string>
   <string name="np_region_finland">Finnland</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Frankreich</string>
   <string name="np_name_francenortheast">Frankreich Nordost</string>
   <string name="np_desc_francenortheast">Straßburg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -224,7 +224,6 @@
   <string name="np_desc_rt">Μόνο τρένα μεγάλων αποστάσεων</string>
   <string name="np_desc_rt_networks">Railteam συμμαχία</string>
   <string name="np_region_finland">Φιλλανδία</string>
-  <string name="np_desc_hsl">Ελσίνκι</string>
   <string name="np_region_france">Γαλλία</string>
   <string name="np_name_francenortheast">Γαλλία Βόρεια Ανατολικά</string>
   <string name="np_desc_francenortheast">Στρασβούργο, Μέτσε, Λίλη, Νανσί</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -205,7 +205,6 @@ Tiu ĉi aplikaĵo uzas datumojn de diversaj lokaj firmaoj de publika transporto 
   <string name="np_desc_rt">Nur long-distancaj vagonaroj</string>
   <string name="np_desc_rt_networks">Societo Railteam</string>
   <string name="np_region_finland">Suomujo</string>
-  <string name="np_desc_hsl">Helsinko</string>
   <string name="np_region_france">Francujo</string>
   <string name="np_name_francenortheast">Francujo nord-orienta</string>
   <string name="np_desc_francenortheast">Strasburgo, Metz, Lillo, Nancio</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -173,7 +173,6 @@ Inténtelo de nuevo más tarde, por favor.</string>
   <string name="np_desc_rt">sólo larga distancia</string>
   <string name="np_desc_rt_networks">Alianza Railteam</string>
   <string name="np_region_finland">Finlandia</string>
-  <string name="np_desc_hsl">Hélsinki</string>
   <string name="np_region_france">Francia</string>
   <string name="np_name_francenortheast">Noreste de Francia</string>
   <string name="np_desc_francenortheast">Estrasburgo, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -183,7 +183,6 @@
   <string name="np_desc_rt">Distantzia handiko trenak soilik</string>
   <string name="np_desc_rt_networks">Railteam aliantza</string>
   <string name="np_region_finland">Finlandia</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Frantzia</string>
   <string name="np_name_francenortheast">Frantzia ipar ekialdea</string>
   <string name="np_desc_francenortheast">Estrasburgo, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -214,7 +214,6 @@ Elle n’utilise pas non plus des outils de suivi comme Google Analytics pour vo
   <string name="np_desc_rt">Trains longue distance seulement</string>
   <string name="np_desc_rt_networks">Alliance Railteam</string>
   <string name="np_region_finland">Finlande</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">France</string>
   <string name="np_name_francenortheast">France — Nord-est</string>
   <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -228,7 +228,6 @@ hogy hol kell leszállnia a buszról…
   <string name="np_desc_rt">Csak távolsági vonatok </string>
   <string name="np_desc_rt_networks">Railteam szövetség</string>
   <string name="np_region_finland">Finnország</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Franciaország</string>
   <string name="np_name_francenortheast">Északkelet-Franciaország</string>
   <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -224,7 +224,6 @@ e mostra sempre dove sei per non perderti la fermata dove devi scendere.
   <string name="np_desc_rt">Solo treni a lunga percorrenza</string>
   <string name="np_desc_rt_networks">Railteam</string>
   <string name="np_region_finland">Finlandia</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Francia</string>
   <string name="np_name_francenortheast">Francia nord-orientale</string>
   <string name="np_desc_francenortheast">Strasburgo, Metz, Lilla, Nancy</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -163,7 +163,6 @@
   <string name="np_desc_rt">長距離列車のみ</string>
   <string name="np_desc_rt_networks">鉄道アライアンス</string>
   <string name="np_region_finland">フィンランド</string>
-  <string name="np_desc_hsl">ヘルシンキ</string>
   <string name="np_region_france">フランス</string>
   <string name="np_name_francenortheast">フランス北東部</string>
   <string name="np_desc_francenortheast">ストラスブール、メッツ、リール、ナンシー</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -164,7 +164,6 @@
   <string name="np_desc_rt">Bare langdistansetog</string>
   <string name="np_desc_rt_networks">Railteam-alliansen</string>
   <string name="np_region_finland">Finland</string>
-  <string name="np_desc_hsl">Helsingfors</string>
   <string name="np_region_france">Frankrike</string>
   <string name="np_name_francenortheast">Frankrike nord-øst</string>
   <string name="np_desc_francenortheast">Straßburg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -205,7 +205,6 @@ Deze app gebruikt de gegevens van verschillende lokale openbaar vervoersaanbiede
   <string name="np_desc_rt">Alleen langeafstandstreinen</string>
   <string name="np_desc_rt_networks">Railteam-alliantie</string>
   <string name="np_region_finland">Finland</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Frankrijk</string>
   <string name="np_name_francenortheast">Noordoosten van Frankrijk</string>
   <string name="np_desc_francenortheast">Straatsburg, Metz, Rijsel, Nancy</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -207,7 +207,6 @@ Ta aplikacja korzysta z wielu dostawców danych transportu publicznego i dostarc
   <string name="np_desc_rt">Tylko pociągi długodystansowe</string>
   <string name="np_desc_rt_networks">Sieć Railteam</string>
   <string name="np_region_finland">Finlandia</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Francja</string>
   <string name="np_name_francenortheast">Francja północno-wschodnia</string>
   <string name="np_desc_francenortheast">Strasbourg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -172,7 +172,6 @@
   <string name="np_desc_rt">Apenas trens de longa distancia</string>
   <string name="np_desc_rt_networks">aliança Railteam</string>
   <string name="np_region_finland">Finlândia</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">França</string>
   <string name="np_name_francenortheast">Nordeste da França</string>
   <string name="np_desc_francenortheast">Estrasburgo, Metz, Lila, Nanci</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -226,7 +226,6 @@ Transportr сохраняет часто используемые местопо
   <string name="np_desc_rt">Только поезда дальнего следования</string>
   <string name="np_desc_rt_networks">Railteam alliance</string>
   <string name="np_region_finland">Финляндия</string>
-  <string name="np_desc_hsl">Хельсинки</string>
   <string name="np_region_france">Франция</string>
   <string name="np_name_francenortheast">Франция Северо-Восток</string>
   <string name="np_desc_francenortheast">Страсбург, Нанси, Лилль, Нанси</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -76,7 +76,6 @@
   <string name="np_desc_dsb">டென்மார்க், கோபன்ஹேகன்</string>
   <string name="np_name_rt">ஐரோப்பா</string>
   <string name="np_region_finland">ஃபின்லாந்து</string>
-  <string name="np_desc_hsl">ஹெல்சின்கி</string>
   <string name="np_region_france">பிரான்ஸ்</string>
   <string name="np_name_paris">பாரிஸ்</string>
   <string name="np_region_gb">கிரேட் பிரட்டன்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -140,7 +140,6 @@
   <string name="np_name_rt">Avrupa</string>
   <string name="np_desc_rt">Sadece Uzun Yol Trenleri</string>
   <string name="np_region_finland">Finlandiya</string>
-  <string name="np_desc_hsl">Helsinki</string>
   <string name="np_region_france">Fransa</string>
   <string name="np_name_francenortheast">Kuzey Doğu Fransa</string>
   <string name="np_desc_francenortheast">Strazburg, Metz, Lille, Nancy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -272,7 +272,8 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="np_desc_rt_networks">Railteam alliance</string>
 
 	<string name="np_region_finland">Finland</string>
-	<string name="np_desc_hsl">Helsinki</string>
+	<string name="np_desc_fi">Helsinki, Turku, Tampere, Jyväskylä, Oulu</string>
+	<string name="np_desc_fi_networks" translatable="false">HSL, Föli, TKL, Linkki, Oulun joukkoliikenne</string>
 
 	<string name="np_region_france">France</string>
 	<string name="np_name_francenortheast">France North East</string>

--- a/artwork/networks/network_fi_logo.svg
+++ b/artwork/networks/network_fi_logo.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="network_fi_logo.svg"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     id="namedview10"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="10.24"
+     inkscape:cx="50.526886"
+     inkscape:cy="28.326079"
+     inkscape:window-x="640"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <rect
+     width="64"
+     height="64"
+     x="0"
+     id="rect4"
+     y="0"
+     style="fill:#ffffff;stroke-width:26.12788963" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#003580;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 17 0 L 17 23 L 0 23 L 0 41 L 17 41 L 17 64 L 35 64 L 35 41 L 64 41 L 64 23 L 35 23 L 35 0 L 17 0 z "
+     id="rect4519" />
+</svg>


### PR DESCRIPTION
Now that `HslProvider` is based on the Navitia API, the data set it uses covers a few more parts of the country than just Helsinki. This changes the description and logo of the provider to reflect that.

Related issue: #493

----

~~I took the liberty of also updating the Spanish strings, because it is my native language after all :wink:~~

This is how it looks with this patch applied:

![Transportrt with HSL provider information modified to show that it covers more of Finland](https://user-images.githubusercontent.com/723451/44298495-beb03280-a2ec-11e8-9f8f-229f5357cefa.png)
