### PR TITLE
Add notification support on DeparturesActivity for e.g. smartwatches

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-	package="de.grobox.transportr"
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools"
-	android:installLocation="auto">
+<manifest package="de.grobox.transportr"
+		  xmlns:android="http://schemas.android.com/apk/res/android"
+		  xmlns:tools="http://schemas.android.com/tools"
+		  android:installLocation="auto">
 
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
@@ -29,7 +28,7 @@
 		android:required="false"/>
 
 	<application
-		android:name="de.grobox.transportr.TransportrApplication"
+		android:name=".TransportrApplication"
 		android:allowBackup="false"
 		android:hardwareAccelerated="true"
 		android:icon="@mipmap/ic_launcher"
@@ -38,56 +37,50 @@
 		android:supportsRtl="true"
 		android:theme="@style/AppTheme.Light"
 		tools:ignore="AllowBackup,GoogleAppIndexingWarning">
-
 		<activity
-			android:name="de.grobox.transportr.map.MapActivity"
+			android:name=".map.MapActivity"
 			android:label="@string/app_name"
 			android:launchMode="singleTop"
 			android:windowSoftInputMode="stateHidden|adjustPan">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
+
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW"/>
+
 				<data android:scheme="geo"/>
+
 				<category android:name="android.intent.category.DEFAULT"/>
 			</intent-filter>
 
 			<meta-data
 				android:name="android.app.shortcuts"
 				android:resource="@xml/shortcuts"/>
-
 		</activity>
-
 		<activity
-			android:name="de.grobox.transportr.trips.search.DirectionsActivity"
+			android:name=".trips.search.DirectionsActivity"
 			android:exported="true"
 			android:windowSoftInputMode="stateHidden"/>
-
 		<activity
-			android:name="de.grobox.transportr.departures.DeparturesActivity"
+			android:name=".departures.DeparturesActivity"
 			android:label="@string/drawer_departures"
-			android:parentActivityName="de.grobox.transportr.map.MapActivity"
+			android:parentActivityName=".map.MapActivity"
 			tools:targetApi="jelly_bean"/>
-
 		<activity
-			android:name="de.grobox.transportr.trips.detail.TripDetailActivity"
-			android:parentActivityName="de.grobox.transportr.trips.search.DirectionsActivity"
+			android:name=".trips.detail.TripDetailActivity"
+			android:parentActivityName=".trips.search.DirectionsActivity"
 			tools:targetApi="jelly_bean"/>
-
 		<activity
-			android:name="de.grobox.transportr.networks.PickTransportNetworkActivity"
+			android:name=".networks.PickTransportNetworkActivity"
 			android:label="@string/pick_network_activity"/>
-
 		<activity
-			android:name="de.grobox.transportr.settings.SettingsActivity"
+			android:name=".settings.SettingsActivity"
 			android:label="@string/drawer_settings"/>
-
 		<activity
-			android:name="de.grobox.transportr.about.AboutActivity"
+			android:name=".about.AboutActivity"
 			android:label="@string/drawer_about"/>
-
 		<activity
 			android:name=".about.ContributorsActivity"
 			android:label="@string/drawer_contributors"/>

--- a/app/src/main/java/de/grobox/transportr/utils/DateUtils.java
+++ b/app/src/main/java/de/grobox/transportr/utils/DateUtils.java
@@ -117,7 +117,7 @@ public class DateUtils {
 		}
 	}
 
-	private static long getDifferenceInMinutes(Date date) {
+	public static long getDifferenceInMinutes(Date date) {
 		return getDelay(new Date(), date);
 	}
 

--- a/app/src/main/res/drawable/action_notification.xml
+++ b/app/src/main/res/drawable/action_notification.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+</vector>

--- a/app/src/main/res/menu/departures.xml
+++ b/app/src/main/res/menu/departures.xml
@@ -8,5 +8,10 @@
 		android:icon="@drawable/ic_time"
 		android:title="@string/change_time"
 		app:showAsAction="always"/>
+	<item
+		android:id="@+id/action_notification"
+		android:icon="@drawable/action_notification"
+		android:title="@string/change_time"
+		app:showAsAction="always"/>
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,5 +444,7 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="japanese">Japanese</string>
 	<string name="russian">Russian</string>
 	<string name="greek">Greek</string>
+	<string name="channel_name">DepartuesNotification</string>
+	<string name="channel_description">Ticker notifications</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="for_x_min">for %d min</string>
 
 	<string name="change_time">Change Time</string>
+	<string name="start_notifications">Start Notifications</string>
 	<string name="now">Now</string>
 	<string name="now_small">now</string>
 	<string name="yesterday">Yesterday</string>


### PR DESCRIPTION
Getting something countdown-like for the next departures per station on my pebble watch was always on my wishlist for my public transit "workflow". I used transportr before, so I forked this for a hackathon and just did it. Maybe it's useful for the main app.
Using notifications here seemed like a good idea, because that's vendor agnostic and even not completely useless without such a watch. The notifications should update every 30s. Notifications can be toggled for 10 Minutes with a menu button in the DeparturesActivity.
![img_20181027_131651 1](https://user-images.githubusercontent.com/20602537/47762221-06274780-dcbc-11e8-9ac3-af2da4547eea.jpg)