### PR TITLE
Correction translation of "South America" into Brazilian Portuguese.

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -145,7 +145,7 @@
   <string name="np_continent_africa">África</string>
   <string name="np_continent_north_america">América do Norte</string>
   <string name="np_continent_central_america">América Central</string>
-  <string name="np_continent_south_america">América Central</string>
+  <string name="np_continent_south_america">América do Sul</string>
   <string name="np_continent_asia">Ásia</string>
   <string name="np_continent_oceania">Oceania</string>
   <string name="np_region_australia">Austrália</string>


### PR DESCRIPTION
Central America and South America were translated as "América Central".