### PR TITLE
Fix trip delays

### DIFF
--- a/app/src/main/java/de/grobox/transportr/trips/BaseViewHolder.kt
+++ b/app/src/main/java/de/grobox/transportr/trips/BaseViewHolder.kt
@@ -17,7 +17,7 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package de.grobox.transportr.trips.detail
+package de.grobox.transportr.trips
 
 import android.content.Context
 import android.view.View
@@ -33,7 +33,7 @@ import de.schildbach.pte.dto.Position
 import de.schildbach.pte.dto.Stop
 import java.util.*
 
-internal abstract class BaseViewHolder(v: View, protected val listener: LegClickListener) : RecyclerView.ViewHolder(v) {
+internal abstract class BaseViewHolder(v: View) : RecyclerView.ViewHolder(v) {
 
     protected val context: Context = v.context
     protected val fromTime: TextView = v.findViewById(R.id.fromTime)
@@ -41,7 +41,7 @@ internal abstract class BaseViewHolder(v: View, protected val listener: LegClick
     protected val fromDelay: TextView = v.findViewById(R.id.fromDelay)
     protected val toDelay: TextView = v.findViewById(R.id.toDelay)
 
-    fun setArrivalTimes(timeView: TextView, delayView: TextView, stop: Stop) {
+    fun setArrivalTimes(timeView: TextView?, delayView: TextView, stop: Stop) {
         if (stop.arrivalTime == null) return
 
         val time = Date(stop.arrivalTime.time)
@@ -58,10 +58,10 @@ internal abstract class BaseViewHolder(v: View, protected val listener: LegClick
         } else {
             delayView.visibility = GONE
         }
-        timeView.text = getTime(context, time)
+        timeView?.let { it.text = getTime(context, time) }
     }
 
-    fun setDepartureTimes(timeView: TextView, delayView: TextView, stop: Stop) {
+    fun setDepartureTimes(timeView: TextView?, delayView: TextView, stop: Stop) {
         if (stop.departureTime == null) return
 
         val time = Date(stop.departureTime.time)
@@ -78,7 +78,7 @@ internal abstract class BaseViewHolder(v: View, protected val listener: LegClick
         } else {
             delayView.visibility = GONE
         }
-        timeView.text = getTime(context, time)
+        timeView?.let { it.text = getTime(context, time) }
     }
 
     protected fun TextView.addPlatform(position: Position?) {

--- a/app/src/main/java/de/grobox/transportr/trips/detail/LegViewHolder.kt
+++ b/app/src/main/java/de/grobox/transportr/trips/detail/LegViewHolder.kt
@@ -33,6 +33,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.common.base.Strings
 import com.google.common.base.Strings.isNullOrEmpty
 import de.grobox.transportr.R
+import de.grobox.transportr.trips.BaseViewHolder
 import de.grobox.transportr.trips.detail.LegViewHolder.LegType.*
 import de.grobox.transportr.ui.LineView
 import de.grobox.transportr.utils.DateUtils
@@ -45,7 +46,7 @@ import de.schildbach.pte.dto.Trip.*
 import kotlinx.android.synthetic.main.list_item_leg.view.*
 
 
-internal class LegViewHolder(v: View, listener: LegClickListener, private val showLineName: Boolean) : BaseViewHolder(v, listener) {
+internal class LegViewHolder(v: View, private val listener: LegClickListener, private val showLineName: Boolean) : BaseViewHolder(v) {
 
     internal enum class LegType {
         FIRST, MIDDLE, LAST, FIRST_LAST

--- a/app/src/main/java/de/grobox/transportr/trips/detail/StopViewHolder.kt
+++ b/app/src/main/java/de/grobox/transportr/trips/detail/StopViewHolder.kt
@@ -26,12 +26,13 @@ import android.view.View.VISIBLE
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
+import de.grobox.transportr.trips.BaseViewHolder
 import de.grobox.transportr.utils.TransportrUtils.getLocationName
 import de.schildbach.pte.dto.Stop
 import kotlinx.android.synthetic.main.list_item_stop.view.*
 
 
-internal class StopViewHolder(v: View, listener: LegClickListener) : BaseViewHolder(v, listener) {
+internal class StopViewHolder(v: View, private val listener : LegClickListener) : BaseViewHolder(v) {
 
     private val circle: ImageView = v.circle
     private val stopLocation: TextView = v.stopLocation

--- a/app/src/main/java/de/grobox/transportr/utils/DateUtils.java
+++ b/app/src/main/java/de/grobox/transportr/utils/DateUtils.java
@@ -81,15 +81,8 @@ public class DateUtils {
 		return (delay > 0 ? "+" : "") + Long.toString(delay);
 	}
 
-	@Nullable
 	public static String getDelayText(long delay) {
-		if (delay >= 0) {
-			return "+" + Long.toString(delay / 1000 / 60);
-		} else if (delay < 0) {
-			return "-" + Long.toString(delay / 1000 / 60);
-		} else {
-			return null;
-		}
+		return (delay >= 0 ? "+" : "") + Long.toString(delay / 1000 / 60);
 	}
 
 	public static boolean isToday(Calendar calendar) {


### PR DESCRIPTION
This PR unifies the delay handling for `trips.search` with `trips.detail` and by doing so applies the right color to trips with "negative delay" (so public transport services ahead of their time). It also fixes the bug to not display a double minus in front of such delays.

The second commit just moves `BaseViewHolder` to the `trips` package as it is now used by both subpackages.

Fixes #575 