### PR TITLE
Don't search with via location if via field is hidden

### DIFF
--- a/app/src/main/java/de/grobox/transportr/trips/search/DirectionsViewModel.java
+++ b/app/src/main/java/de/grobox/transportr/trips/search/DirectionsViewModel.java
@@ -224,7 +224,11 @@ public class DirectionsViewModel extends SavedSearchesViewModel implements TimeD
 			if (calendar == null) return;
 		}
 
-		TripQuery tripQuery = new TripQuery(fromLocation.getValue(), viaLocation.getValue(), toLocation.getValue(),
+		WrapLocation via = null;
+		if (isExpanded.getValue() != null && isExpanded.getValue())
+			via = viaLocation.getValue();
+
+		TripQuery tripQuery = new TripQuery(fromLocation.getValue(), via, toLocation.getValue(),
 				calendar.getTime(), isDeparture.getValue(), products.getValue());
 
 		tripsRepository.search(tripQuery);


### PR DESCRIPTION
This PR addresses #522 and solves even a greater issue: If a via location has been chosen before hiding the via location field, the via location is still used to perform the query.

Unfortunately, Android Studio reports an "Unboxing of `isExpanded.getValue()` may produce a NullPointerException" warning, the only way to avoid this is to check manually for `null` type (which should never happen btw, as `isExpanded` is instantiated when instantiating the `ViewModel`). Not sure what would be the way to go in this case.

Fixes #522 