### PR TITLE
Align stops in TripDetailsFragment even without times

### DIFF
--- a/app/src/main/java/de/grobox/transportr/trips/detail/StopViewHolder.kt
+++ b/app/src/main/java/de/grobox/transportr/trips/detail/StopViewHolder.kt
@@ -21,15 +21,16 @@ package de.grobox.transportr.trips.detail
 
 
 import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
+import android.view.View.*
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import de.grobox.transportr.trips.BaseViewHolder
+import de.grobox.transportr.utils.DateUtils.getTime
 import de.grobox.transportr.utils.TransportrUtils.getLocationName
 import de.schildbach.pte.dto.Stop
 import kotlinx.android.synthetic.main.list_item_stop.view.*
+import java.util.Date
 
 
 internal class StopViewHolder(v: View, private val listener : LegClickListener) : BaseViewHolder(v) {
@@ -41,8 +42,16 @@ internal class StopViewHolder(v: View, private val listener : LegClickListener) 
     fun bind(stop: Stop, color: Int) {
         if (stop.arrivalTime != null) {
             setArrivalTimes(fromTime, fromDelay, stop)
+            fromTime.visibility = VISIBLE
         } else {
             fromDelay.visibility = GONE
+            if (stop.departureTime == null) {
+                // insert dummy time field for stops without times set, so that stop circles align
+                fromTime.text = getTime(context, Date())
+                fromTime.visibility = INVISIBLE
+            } else {
+                fromTime.visibility = GONE
+            }
         }
 
         if (stop.departureTime != null) {


### PR DESCRIPTION
When no `arrivalTime` is set, the width of the `fromTime` TextView is changed to the width of the formatted current time, preventing aligning errors.

Fixes #587 