### PR TITLE
Add proguard rule to keep path serialization

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -44,6 +44,11 @@
 -keep class de.schildbach.pte.dto.**
 -dontwarn de.schildbach.pte.**
 
+-keepclassmembers class * implements java.io.Serializable {
+	private void writeObject(java.io.ObjectOutputStream);
+	private void readObject(java.io.ObjectInputStream);
+}
+
 -keep class de.grobox.transportr.**
 -dontwarn de.grobox.transportr.data.**
 -dontnote de.grobox.transportr.ui.**


### PR DESCRIPTION
This is the result of the work done and logged in #585: It just adds four lines to the Proguard rules to prevent throwing serialization methods for `Trip.path` away.

Fixes #585.