### PR TITLE
Better handling for reporting PTE issues

### DIFF
--- a/app/src/main/java/de/grobox/transportr/trips/search/DirectionsViewModel.java
+++ b/app/src/main/java/de/grobox/transportr/trips/search/DirectionsViewModel.java
@@ -19,6 +19,8 @@
 
 package de.grobox.transportr.trips.search;
 
+import android.util.Pair;
+
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.Set;
@@ -249,6 +251,10 @@ public class DirectionsViewModel extends SavedSearchesViewModel implements TimeD
 
 	LiveData<String> getQueryError() {
 		return tripsRepository.getQueryError();
+	}
+
+	LiveData<Pair<String,String>> getQueryPTEError() {
+		return tripsRepository.getQueryPTEError();
 	}
 
 	LiveData<String> getQueryMoreError() {

--- a/app/src/main/java/de/grobox/transportr/trips/search/TripsFragment.java
+++ b/app/src/main/java/de/grobox/transportr/trips/search/TripsFragment.java
@@ -22,7 +22,12 @@ package de.grobox.transportr.trips.search;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.CountDownTimer;
-import android.text.util.Linkify;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
+import android.util.Log;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -35,6 +40,7 @@ import com.omadahealth.github.swipyrefreshlayout.library.SwipyRefreshLayout.OnRe
 import com.omadahealth.github.swipyrefreshlayout.library.SwipyRefreshLayoutDirection;
 
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -51,6 +57,7 @@ import de.grobox.transportr.trips.detail.TripDetailActivity;
 import de.grobox.transportr.trips.search.TripAdapter.OnTripClickListener;
 import de.grobox.transportr.trips.search.TripsRepository.QueryMoreState;
 import de.grobox.transportr.ui.LceAnimator;
+import de.grobox.transportr.utils.Linkify;
 import de.schildbach.pte.dto.Trip;
 
 import static com.omadahealth.github.swipyrefreshlayout.library.SwipyRefreshLayoutDirection.BOTH;
@@ -119,6 +126,7 @@ public class TripsFragment extends TransportrFragment implements OnRefreshListen
 		viewModel.getQueryMoreState().observe(this, this::updateSwipeState);
 		viewModel.getTrips().observe(this, this::onTripsLoaded);
 		viewModel.getQueryError().observe(this, this::onError);
+		viewModel.getQueryPTEError().observe(this, this::onPTEError);
 		viewModel.getQueryMoreError().observe(this, this::onMoreError);
 
 		adapter = new TripAdapter(this);
@@ -189,9 +197,15 @@ public class TripsFragment extends TransportrFragment implements OnRefreshListen
 
 	private void onError(@Nullable String error) {
 		if (error == null) return;
-		errorText.setText(error + "\n\n" + getString(R.string.trip_error_pte));
+		errorText.setText(error);
+		showErrorView(progressBar, list, errorLayout);
+	}
+
+	private void onPTEError(@Nullable Pair<String,String> error) {
+		if (error == null) return;
+		errorText.setText(error.first + "\n\n" + getString(R.string.trip_error_pte));
 		Pattern pteMatcher = Pattern.compile("public-transport-enabler");
-		Linkify.addLinks(errorText, pteMatcher, "https://github.com/schildbach/public-transport-enabler/issues");
+		Linkify.addLinks(errorText, pteMatcher, error.second);
 		showErrorView(progressBar, list, errorLayout);
 	}
 

--- a/app/src/main/java/de/grobox/transportr/trips/search/TripsFragment.java
+++ b/app/src/main/java/de/grobox/transportr/trips/search/TripsFragment.java
@@ -203,7 +203,7 @@ public class TripsFragment extends TransportrFragment implements OnRefreshListen
 
 	private void onPTEError(@Nullable Pair<String,String> error) {
 		if (error == null) return;
-		errorText.setText(error.first + "\n\n" + getString(R.string.trip_error_pte));
+		errorText.setText(error.first + "\n\n" + getString(R.string.trip_error_pte, "public-transport-enabler"));
 		Pattern pteMatcher = Pattern.compile("public-transport-enabler");
 		Linkify.addLinks(errorText, pteMatcher, error.second);
 		showErrorView(progressBar, list, errorLayout);

--- a/app/src/main/java/de/grobox/transportr/utils/Linkify.java
+++ b/app/src/main/java/de/grobox/transportr/utils/Linkify.java
@@ -1,0 +1,68 @@
+/*
+ *    Transportr
+ *
+ *    Copyright (c) 2013 - 2019 Torsten Grote
+ *
+ *    This program is Free Software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as
+ *    published by the Free Software Foundation, either version 3 of the
+ *    License, or (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.grobox.transportr.utils;
+
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
+import android.widget.TextView;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import androidx.annotation.NonNull;
+
+/**
+ *  Linkify is a simplified version of android.text.Linkify
+ *  which doesn't care about schemes or lower-casing the url,
+ *  but just adds a clickable link to every match of the given pattern.
+ */
+public class Linkify {
+
+	/**
+	 *  Applies a regex to the text of a TextView turning the matches into
+	 *  links.  If links are found then UrlSpans are applied to the link
+	 *  text match areas, and the movement method for the text is changed
+	 *  to LinkMovementMethod.
+	 *
+	 *  @param textView TextView whose text is to be marked-up with links.
+	 *  @param pattern Regex pattern to be used for finding links.
+	 *  @param url The url to be used linked to.
+	 */
+	public static boolean addLinks(@NonNull TextView textView, @NonNull Pattern pattern, @NonNull String url) {
+		SpannableString spannable = SpannableString.valueOf(textView.getText());
+
+		boolean found = false;
+		Matcher m = pattern.matcher(spannable);
+		while (m.find()) {
+			int start = m.start();
+			int end = m.end();
+			URLSpan span = new URLSpan(url);
+			spannable.setSpan(span, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+			found = true;
+		}
+
+		textView.setText(spannable);
+		textView.setMovementMethod(LinkMovementMethod.getInstance());
+
+		return found;
+	}
+}

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -142,7 +142,6 @@ i sempre saber on ets per no perdre on baixar de l\'autobús. ]]></string>
   <string name="trip_error_no_trips">No s\'ha trobat cap connexió :(</string>
   <string name="trip_error_invalid_date">Actualment, la data de cerca no és compatible amb el proveïdor de dades. Prova\'n un altre.</string>
   <string name="trip_error_service_down">El proveïdor de dades actualment no està disponible: (\nProva-ho de nou més tard.</string>
-  <string name="trip_error_pte">Si vols informar d\'aquest error, envia\'l directament a public-transport-enabler i adjunta una captura de pantalla.</string>
   <string name="trip_issue">Potser hi ha un problema amb aquesta connexió.</string>
   <string name="try_again">Tornar-ho a provar</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -138,7 +138,6 @@ und weiß immer, wo man aussteigen muss.
   <string name="trip_error_no_trips">Keine Verbindungen gefunden :(</string>
   <string name="trip_error_invalid_date">Das Suchdatum wird momentan nicht von der Datenquelle unterstützt. Bitte versuche ein anderes Datum.</string>
   <string name="trip_error_service_down">Die Datenquelle ist momentan nicht erreichbar :(\nBitte versuche es später noch einmal.</string>
-  <string name="trip_error_pte">Wenn du diesen Fehler melden möchtest, kannst du ihn bitte direkt an den Public Transport Enabler melden und einen Screenshot hinzufügen.</string>
   <string name="trip_issue">Es könnte ein Problem mit dieser Verbindung geben.</string>
   <string name="try_again">Noch einmal versuchen</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -134,7 +134,6 @@
   <string name="trip_error_no_trips">Δεν μπόρεσαν να βρεθούν σύνδεσμοι :(</string>
   <string name="trip_error_invalid_date">Η ημερομηνία αναζήτησης δεν υποστηρίζεται προς το παρόν από τον πάροχο δεδομένων. Παρακαλώ δοκιμάστε άλλη ημερομηνία.</string>
   <string name="trip_error_service_down">Ο πάροχος δεδομένων είναι προς το παρόν μη διαθέσιμος :(\nΠαρακαλώ δοκιμάστε ξανά αργότερα.</string>
-  <string name="trip_error_pte">Αν θέλετε να αναφέρετε αυτό το σφάλμα, παρακαλώ αναφέρετε το απ\'΄ευθείας στο public-transport-enabler και επισυνάψτε μια οθονολήψη.</string>
   <string name="trip_issue">Ίσως να υπάρχει πρόβλημα με αυτή τη σύνδεση.</string>
   <string name="try_again">Δοκιμάστε ξανά</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -119,7 +119,6 @@ Tiu ĉi aplikaĵo uzas datumojn de diversaj lokaj firmaoj de publika transporto 
   <string name="trip_error_no_trips">Ne povas trovi komunikiloj :(</string>
   <string name="trip_error_invalid_date">La serĉita dato ne estas nuntempe subtenata de la datum-provizanto. Bonvolu provi alian daton.</string>
   <string name="trip_error_service_down">La datum-provizanto nuntempe malfunkcias :(\nBonvolu provi denove poste.</string>
-  <string name="trip_error_pte">Se vi volas raporti tiun ĉi eraron, bonvolu raporti ĝin al senpere al public-transport-enabler kaj kunigu ekranokopion.</string>
   <string name="trip_issue">Povas okazi problemo kun tiu ĉi komunikilo.</string>
   <string name="try_again">Reprovi</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -133,7 +133,6 @@ para que sepas siempre dónde estas, y que así no te olvides dónde bajarte del
   <string name="trip_error_invalid_date">El proveedor de datos no permite esta búsqueda por fecha. Pruebe con otra fecha.</string>
   <string name="trip_error_service_down">El proveedor de datos está fuera de servicio :(
 Inténtelo de nuevo más tarde, por favor.</string>
-  <string name="trip_error_pte">Si quieres informar de este error, por favor, informa primero a la fuente de los datos de transporte público y adjunta una captura de pantalla.</string>
   <string name="trip_issue">Puede haber un problema con esta conexión.</string>
   <string name="try_again">Intentar de nuevo</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -138,7 +138,6 @@ eta beti daki non zauden autobusetik non jaitsi jakin dezazun.
   <string name="trip_error_no_trips">Ezin izan da garraioen konexiorik aurkitu :(</string>
   <string name="trip_error_invalid_date">Datuen hornitzaileak ez du bilaketa data onartzen. Saiatu beste data batekin.</string>
   <string name="trip_error_service_down">Datuen hornitzailea ez dago eskuragarri:(\n Saiatu geroago.</string>
-  <string name="trip_error_pte">Errore honen berri eman nahi baduzu, egizu public-transport-enabler proiektuan zuzenean eta gehitu pantaila-argazki bat.</string>
   <string name="trip_issue">Arazoren bat egon daiteke konexio honekin.</string>
   <string name="try_again">Saiatu berriro</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -139,7 +139,6 @@ Transportr مکان ها و سفر های انجام شده متداول را ذ
   <string name="trip_error_invalid_date">تاریخ جستجو توسط تامین کننده داده پشتیبانی نمی شود. لطفا یک تاریخ دیگر را امتحان کنید.</string>
   <string name="trip_error_service_down">تامین کننده داده هم اکنون برقرار نمی باشد :(
 لطفا بعدا امتحان کنید.</string>
-  <string name="trip_error_pte">اگر میخواهید این خطاء را گزارش کنید، لطفا آن را به صورت مستقیم به public-transport-enabler گزارش کنید و یک اسکرین شات به همراه آن بفرستید.</string>
   <string name="trip_issue">ممکن است با این کانکشن اشکالی وجود داشته باشد.</string>
   <string name="try_again">دوباره امتحان کنید</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -128,7 +128,6 @@ Elle n’utilise pas non plus des outils de suivi comme Google Analytics pour vo
   <string name="trip_error_no_trips">Aucune correspondance n’a été trouvée :(</string>
   <string name="trip_error_invalid_date">La date d’interrogation n’est actuellement pas prise en charge par le fournisseur de données. Veuillez essayer une autre date.</string>
   <string name="trip_error_service_down">Le fournisseur de données est actuellement hors service :(\nVeuillez ressayer ultérieurement.</string>
-  <string name="trip_error_pte">Si vous souhaitez signaler cette erreur, veuillez la signaler directement à « public-transport-enabler » et joignez une capture d’écran.</string>
   <string name="trip_issue">Cette correspondance pourrait présenter un problème.</string>
   <string name="try_again">Ressayer</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -142,7 +142,6 @@ hogy hol kell leszállnia a buszról…
   <string name="trip_error_no_trips">Nem találhatók csatlakozások :(</string>
   <string name="trip_error_invalid_date">A keresési dátumot jelenleg nem támogatja az adatszolgáltató. Próbáljon egy másik dátumot.</string>
   <string name="trip_error_service_down">Az adatszolgáltató jelenleg nem érhető el :(\nPróbálja meg később.</string>
-  <string name="trip_error_pte">Ha jelenteni szeretné ezt a hibát, akkor követlenül a public-transport-enabler karbantartójának jelentse, és csatoljon egy képernyőképet. </string>
   <string name="trip_issue">Probléma lehet ezzel a csatlakozással.</string>
   <string name="try_again">Próbálja újra</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -138,7 +138,6 @@ e mostra sempre dove sei per non perderti la fermata dove devi scendere.
   <string name="trip_error_no_trips">Nessuna connessione disponibile :(</string>
   <string name="trip_error_invalid_date">Il provider dei dati non supporta attualmente la ricerca per data. Riprova con un\'altra data.</string>
   <string name="trip_error_service_down">Il provider dei dati è attualmente offline :(\nRiprova di nuovo più tardi.</string>
-  <string name="trip_error_pte">Se vuoi segnalare questo errore, fallo direttamente su public-transport-enabler e inserisci uno screenshot.</string>
   <string name="trip_issue">Potrebbe esserci un problema con questa connessione.</string>
   <string name="try_again">Prova ancora</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -138,7 +138,6 @@ Transportr は頻繁に使用される場所や旅行を保存します。
   <string name="trip_error_no_trips">接続が見つかりません :(</string>
   <string name="trip_error_invalid_date">検索日は現在、データプロバイダーによってサポートされていません。 別の日付を試してください。</string>
   <string name="trip_error_service_down">データプロバイダーは現在ダウンしています :(\n後でもう一度やり直してください。</string>
-  <string name="trip_error_pte">このエラーを報告する場合は、スクリーンショットを添付して、直接public-transport-enablerに報告してください。</string>
   <string name="trip_issue">この接続に問題がある可能性があります。</string>
   <string name="try_again">もう一度やり直す</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -89,7 +89,6 @@
   <string name="trip_error_no_trips">Ingen tilkoblinger ble funnet :(</string>
   <string name="trip_error_invalid_date">Søkedatoen er ikke støttet av datatilbyderen. Prøv en annen dato.</string>
   <string name="trip_error_service_down">Datatilbyderen er for tiden nede :(\n Prøv igjen senere.</string>
-  <string name="trip_error_pte">Hvis du ønsker å innrapportere denne feilen, send din rapport til public-transport-enabler direkte og legg ved en skjermavbildning.</string>
   <string name="trip_issue">Det kan være et problem med denne tilkoblingen.</string>
   <string name="try_again">Prøv igjen</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -119,7 +119,6 @@ Deze app gebruikt de gegevens van verschillende lokale openbaar vervoersaanbiede
   <string name="trip_error_no_trips">Geen verbindingen gevonden :(</string>
   <string name="trip_error_invalid_date">De zoekdatum wordt momenteel niet ondersteund door de leverancier. Probeer een andere datum.</string>
   <string name="trip_error_service_down">De leveranciersdienst is momenteel uit de lucht :(\nProbeer het later opnieuw.</string>
-  <string name="trip_error_pte">Als je deze fout wilt rapporteren, doe dat dan naar public-transport-enabler en voeg een schermafbeelding toe.</string>
   <string name="trip_issue">Er is wellicht een probleem met deze verbinding.</string>
   <string name="try_again">Opnieuw proberen</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -119,7 +119,6 @@ Ta aplikacja korzysta z wielu dostawców danych transportu publicznego i dostarc
   <string name="trip_error_no_trips">Nie znaleziono połączeń :(</string>
   <string name="trip_error_invalid_date">Wyszukiwana data nie jest obecnie wspierana przez dostawcę danych. Spróbuj z inną datą.</string>
   <string name="trip_error_service_down">Dostawca danych ma awarię :(\nSpróbuj ponownie później.</string>
-  <string name="trip_error_pte">Jeżeli chcesz zaraportować ten problem, prosimy zgłosić go do bezpośrednio do public-transport-enabler i dołączyć zrzut ekranu.</string>
   <string name="trip_issue">Może być problem z tym połączeniem.</string>
   <string name="try_again">Spróbuj ponownie</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -99,7 +99,6 @@
   <string name="trip_error_no_trips">Nenhuma conexão encontrada :(</string>
   <string name="trip_error_invalid_date">A data buscada não é suportada atualmente pelo provedor de dados. Por favor tente outra data.</string>
   <string name="trip_error_service_down">O provedor de dados está offline :(\nPor favor tente novamente mais tarde.</string>
-  <string name="trip_error_pte">Se quiser reportar esse erro, por favor o faça diretamente a um facilitador de transporte público e anexe uma captura de tela.</string>
   <string name="trip_issue">Pode haver um problema com essas conexão.</string>
   <string name="try_again">Tente novamente</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -137,7 +137,6 @@ Transportr сохраняет часто используемые местопо
   <string name="trip_error_no_trips">Нет интернет-соединения :(</string>
   <string name="trip_error_invalid_date">Дата поиска в настоящее время не поддерживается поставщиком данных. Пожалуйста, попробуйте в другой раз.</string>
   <string name="trip_error_service_down">Поставщик данных в настоящее время не работает :(\Повторите попытку позже.</string>
-  <string name="trip_error_pte">Если вы хотите сообщить об этой ошибке, пожалуйста, сообщите об этом непосредственно в public-transport-enabler и приложите скриншот.</string>
   <string name="trip_issue">Возникла проблема с соединением.</string>
   <string name="try_again">Попробуйте снова</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -138,7 +138,6 @@ och vet alltid var du inte ska missa var du ska gå av bussen.
   <string name="trip_error_no_trips">Inga anslutningar kunde hittas :(</string>
   <string name="trip_error_invalid_date">Sökdatumet stöds för närvarande inte av dataleverantören. Försök med ett annat datum.</string>
   <string name="trip_error_service_down">Dataleverantören är för närvarande nere : (\Vänligen försök igen senare.</string>
-  <string name="trip_error_pte">Om du vill rapportera detta fel, vänligen rapportera det till kollektivtrafiksleverantören direkt och bifoga en skärmdump.</string>
   <string name="trip_issue">Det kan vara ett problem med den här anslutningen.</string>
   <string name="try_again">Försök igen</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -138,7 +138,6 @@ Transportr зберігає часто використовувані місця
   <string name="trip_error_no_trips">Не вдалося знайти жодного маршруту :(</string>
   <string name="trip_error_invalid_date">Дата пошуку наразі не підтримується постачальником даних. Спробуйте іншу дату.</string>
   <string name="trip_error_service_down">Постачальник даних зараз недоступний :(\nПовторіть спробу пізніше.</string>
-  <string name="trip_error_pte">Якщо ви бажаєте повідомити про цю помилку, повідомте про це безпосередньо постачальнику послуг громадського транспорту та додайте знімок екрану.</string>
   <string name="trip_issue">Можлива проблема з цим з\'єднанням.</string>
   <string name="try_again">Повторіть спробу</string>
   <!--This string shows the number of meters one has to walk. Please keep the translation short.-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="trip_error_no_trips">No connections could be found :(</string>
 	<string name="trip_error_invalid_date">The search date is currently not supported by the data provider. Please try another date.</string>
 	<string name="trip_error_service_down">The data provider is currently down :(\nPlease try again later.</string>
-	<string name="trip_error_pte">If you want to report this error, please report it to public-transport-enabler directly.</string>
+	<string name="trip_error_pte">If you want to report this error, please report it to %1$s directly.</string>
 	<string name="trip_issue">There might be a problem with this connection.</string>
 	<string name="trip_not_travelable">Impossible or cancelled</string>
 	<string name="try_again">Try Again</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="trip_error_no_trips">No connections could be found :(</string>
 	<string name="trip_error_invalid_date">The search date is currently not supported by the data provider. Please try another date.</string>
 	<string name="trip_error_service_down">The data provider is currently down :(\nPlease try again later.</string>
-	<string name="trip_error_pte">If you want to report this error, please report it to public-transport-enabler directly and attach a screenshot.</string>
+	<string name="trip_error_pte">If you want to report this error, please report it to public-transport-enabler directly.</string>
 	<string name="trip_issue">There might be a problem with this connection.</string>
 	<string name="trip_not_travelable">Impossible or cancelled</string>
 	<string name="try_again">Try Again</string>


### PR DESCRIPTION
This PR adresses #614 and #615, by implementing the idea mentioned by @TheLastProject:

> Why not just remove the instructions and add a title and body GET param to the new issue URL so it gets prefilled with the correct data? https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters

I had to implement a new simplified `Linkify` method as the official one always lowercases the url. Additionally, the link to PTE is only showed if the error wasn't caused by the internet connection or a `SocketTimeout`.

The prefilled issue message looks like [this](https://github.com/schildbach/public-transport-enabler/issues/new?title=FRANCESOUTHEAST%3A%20java.lang.NullPointerException&body=%23%23%23%20Query%0A-%20NetworkId%3A%20%60FRANCESOUTHEAST%60%0A-%20From%3A%20%60Location%7BPOI%2C%2043.6141750%2F3.8718520%2C%20place%3DMontpellier%2C%20name%3DJardin%20des%20Plantes%7D%60%0A-%20Via%3A%20%60null%60%0A-%20To%3A%20%60Location%7BSTATION%2C%20stop_area%3AOMP%3ASA%3AS5472%2C%2043.6050070%2F3.8791590%2C%20place%3DMontpellier%2C%20name%3DGare%20Saint-Roch%7D%60%0A-%20Date%3A%20%60Sun%20Jul%2021%2014%3A23%3A00%20GMT%2B02%3A00%202019%60%0A-%20Departure%3A%20%60true%60%0A-%20Products%3A%20%60%5BHIGH_SPEED_TRAIN%2C%20REGIONAL_TRAIN%2C%20SUBURBAN_TRAIN%2C%20SUBWAY%2C%20TRAM%2C%20BUS%2C%20FERRY%2C%20CABLECAR%2C%20ON_DEMAND%5D%60%0A-%20Optimize%20for%3A%20%60LEAST_DURATION%60%0A-%20Walk%20Speed%3A%20%60NORMAL%60%0A%0A%23%23%23%20Error%0A%60%60%60%0Ajava.lang.NullPointerException%0Acom.google.common.base.Preconditions.checkNotNull(Preconditions.java%3A890)%0Ade.schildbach.pte.dto.Style.parseColor(Style.java%3A108)%0Ade.schildbach.pte.FranceSouthEastProvider.getLineStyle(FranceSouthEastProvider.java%3A61)%0A%60%60%60%0A%0A%23%23%23%20Additional%20information%0A%5BPlease%20modify%20this%20part%5D%0A) (example for issue schildbach/public-transport-enabler#272):

---

### Query
- NetworkId: `FRANCESOUTHEAST`
- From: `Location{POI, 43.6141750/3.8718520, place=Montpellier, name=Jardin des Plantes}`
- Via: `null`
- To: `Location{STATION, stop_area:OMP:SA:S5472, 43.6050070/3.8791590, place=Montpellier, name=Gare Saint-Roch}`
- Date: `Sun Jul 21 14:23:00 GMT+02:00 2019`
- Departure: `true`
- Products: `[HIGH_SPEED_TRAIN, REGIONAL_TRAIN, SUBURBAN_TRAIN, SUBWAY, TRAM, BUS, FERRY, CABLECAR, ON_DEMAND]`
- Optimize for: `LEAST_DURATION`
- Walk Speed: `NORMAL`

### Error
```
java.lang.NullPointerException
com.google.common.base.Preconditions.checkNotNull(Preconditions.java:890)
de.schildbach.pte.dto.Style.parseColor(Style.java:108)
de.schildbach.pte.FranceSouthEastProvider.getLineStyle(FranceSouthEastProvider.java:61)
```

### Additional information
[Please modify this part]

---

I would be happy to adapt the text if wished. @schildbach would this solution be okay for you?

@grote, I've changed the default (English) string, (how) does Transifex handle this type of changes? Is there anything additional to do?
