### PR TITLE
adapt README to use gradle wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The next step is to clone the source code repository.
 If you don't want to use an IDE like Android Studio, you can build Transportr on the command line as follows.
 
     $ cd Transportr
-    $ gradle assembleRelease
+    $ ./gradlew assembleRelease
 
 License
 -------


### PR DESCRIPTION
This PR adapts the README after switching to gradle wrapper for this project as requested by @grote in https://github.com/grote/Transportr/pull/636#issuecomment-548798473.