### PR TITLE
Departures: Show error if returned list is empty

### DIFF
--- a/app/src/main/java/de/grobox/transportr/departures/DeparturesActivity.java
+++ b/app/src/main/java/de/grobox/transportr/departures/DeparturesActivity.java
@@ -263,7 +263,7 @@ public class DeparturesActivity extends TransportrActivity
 
 	@Override
 	public void onLoadFinished(Loader<QueryDeparturesResult> loader, @Nullable QueryDeparturesResult departures) {
-		if (departures != null && departures.status == OK) {
+		if (departures != null && departures.status == OK && departures.stationDepartures.size() > 0) {
 			for (StationDepartures s : departures.stationDepartures) {
 				adapter.addAll(s.departures);
 			}


### PR DESCRIPTION
This PR partly fixes #623 by checking if PTE returns an empty list. In this case, the error page is shown.