### PR TITLE
Add required OSM and Mapbox attribution

### DIFF
--- a/app/src/main/java/de/grobox/transportr/map/BaseMapFragment.kt
+++ b/app/src/main/java/de/grobox/transportr/map/BaseMapFragment.kt
@@ -20,11 +20,14 @@
 package de.grobox.transportr.map
 
 import android.os.Bundle
+import android.text.Html
+import android.text.method.LinkMovementMethod
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
@@ -37,6 +40,7 @@ import de.grobox.transportr.TransportrFragment
 abstract class BaseMapFragment : TransportrFragment(), OnMapReadyCallback {
 
     protected lateinit var mapView: MapView
+    private lateinit var attribution: TextView
     protected var map: MapboxMap? = null
     protected var mapPadding: Int = 0
 
@@ -48,6 +52,7 @@ abstract class BaseMapFragment : TransportrFragment(), OnMapReadyCallback {
 
         val v = inflater.inflate(layout, container, false)
         mapView = v.findViewById(R.id.map)
+        attribution = v.findViewById(R.id.attribution)
 
         mapPadding = resources.getDimensionPixelSize(R.dimen.mapPadding)
 
@@ -58,6 +63,8 @@ abstract class BaseMapFragment : TransportrFragment(), OnMapReadyCallback {
         super.onViewCreated(view, savedInstanceState)
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
+        attribution.movementMethod = LinkMovementMethod.getInstance()
+        attribution.text = Html.fromHtml(getString(R.string.map_attribution, getString(R.string.map_attribution_improve)))
     }
 
     override fun onStart() {

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
 
@@ -16,6 +17,23 @@
 		app:layout_constraintTop_toTopOf="parent"
 		app:mapbox_uiCompassMarginTop="72dp"
 		app:mapbox_uiRotateGestures="true"/>
+
+	<TextView
+		android:id="@+id/attribution"
+		android:layout_width="0dp"
+		android:layout_height="wrap_content"
+		android:layout_margin="16dp"
+		android:padding="4dp"
+		android:textSize="12sp"
+		android:text="@string/map_attribution"
+		android:background="?attributionBackground"
+		android:textColorLink="?android:textColorTertiary"
+		app:layout_constraintHorizontal_bias="0"
+		app:layout_constraintWidth_default="wrap"
+		app:layout_constraintStart_toStartOf="@+id/map"
+		app:layout_constraintEnd_toStartOf="@id/gpsFab"
+		app:layout_constraintBottom_toBottomOf="@+id/map"
+		tools:text="© OpenStreetMap © Mapbox Improve this map"/>
 
 	<com.google.android.material.floatingactionbutton.FloatingActionButton
 		android:id="@+id/gpsFab"

--- a/app/src/main/res/layout/fragment_trip_map.xml
+++ b/app/src/main/res/layout/fragment_trip_map.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
 
@@ -15,6 +16,23 @@
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toTopOf="parent"
 		app:mapbox_uiCompassMarginTop="24dp"/>
+
+	<TextView
+		android:id="@+id/attribution"
+		android:layout_width="0dp"
+		android:layout_height="wrap_content"
+		android:layout_margin="16dp"
+		android:padding="4dp"
+		android:textSize="12sp"
+		android:text="@string/map_attribution"
+		android:background="?attributionBackground"
+		android:textColorLink="?android:textColorTertiary"
+		app:layout_constraintHorizontal_bias="0"
+		app:layout_constraintWidth_default="wrap"
+		app:layout_constraintStart_toStartOf="@+id/map"
+		app:layout_constraintEnd_toStartOf="@id/gpsFab"
+		app:layout_constraintBottom_toBottomOf="@+id/map"
+		tools:text="© OpenStreetMap © Mapbox Improve this map"/>
 
 	<com.google.android.material.floatingactionbutton.FloatingActionButton
 		android:id="@+id/gpsFab"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
 
     <attr name="mapInfoWindow" format="reference"/>
     <attr name="mapStyle" format="reference"/>
+    <attr name="attributionBackground" format="color"/>
 
     <declare-styleable name="LocationView">
         <attr name="showIcon" format="boolean"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,9 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="about_contributions">This app is Free Software, so you can freely use, study, share and improve it. Contributions are encouraged and appreciated. If you would like to contribute, please visit the homepage for more information.</string>
 	<string name="about_visit_website">Visit Website</string>
 
+	<string name="map_attribution" translatable="false">© &lt;a href="http://www.openstreetmap.org/copyright">OpenStreetMap&lt;/a> © &lt;a href="https://www.mapbox.com/about/maps/">Mapbox&lt;/a> &lt;b>&lt;a href="https://www.mapbox.com/map-feedback/">%1$s&lt;/a>&lt;/b></string>
+	<string name="map_attribution_improve">Improve this map</string>
+
 	<string name="open_navigation_drawer">Open Navigation Drawer</string>
 	<string name="from">From</string>
 	<string name="to">To</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,6 +18,7 @@
         <item name="android:alertDialogTheme">@style/DialogTheme</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="mapStyle">@string/mapbox_style_dark</item>
+        <item name="attributionBackground">#99000000</item>
 
         <item name="about_libraries_card">@color/cardview_dark_background</item>
         <item name="about_libraries_title_openSource">@color/about_libraries_title_openSource_dark</item>
@@ -38,6 +39,7 @@
         <item name="android:alertDialogTheme">@style/DialogTheme</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
         <item name="mapStyle">@string/mapbox_style_mapbox_streets</item>
+        <item name="attributionBackground">#99FFFFFF</item>
     </style>
 
     <style name="AppTheme" parent="AppBaseTheme">


### PR DESCRIPTION
This PR adds attribution to Mapbox and OpenStreetMap as required by the [attribution guidelines](https://docs.mapbox.com/help/how-mapbox-works/attribution/#mapbox-maps-sdk-for-android) to both map fragments in use. On smaller devices, the attribution would be wrapped into two lines.

![Transportr](https://user-images.githubusercontent.com/18088991/76405441-66d29400-6388-11ea-8fe2-cc44481bec90.png)

Fixes #628.