### PR TITLE
Add mapbox logo to attribution

### DIFF
--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -18,11 +18,18 @@
 		app:mapbox_uiCompassMarginTop="72dp"
 		app:mapbox_uiRotateGestures="true"/>
 
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:padding="4dp"
+		app:layout_constraintStart_toStartOf="@+id/attribution"
+		app:layout_constraintBottom_toTopOf="@id/attribution"
+		app:srcCompat="@drawable/mapbox_logo_icon"/>
+
 	<TextView
 		android:id="@+id/attribution"
 		android:layout_width="0dp"
 		android:layout_height="wrap_content"
-		android:layout_margin="16dp"
 		android:padding="4dp"
 		android:textSize="12sp"
 		android:text="@string/map_attribution"

--- a/app/src/main/res/layout/fragment_trip_map.xml
+++ b/app/src/main/res/layout/fragment_trip_map.xml
@@ -17,11 +17,18 @@
 		app:layout_constraintTop_toTopOf="parent"
 		app:mapbox_uiCompassMarginTop="24dp"/>
 
+	<ImageView
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:padding="4dp"
+		app:layout_constraintStart_toStartOf="@+id/attribution"
+		app:layout_constraintBottom_toTopOf="@id/attribution"
+		app:srcCompat="@drawable/mapbox_logo_icon"/>
+
 	<TextView
 		android:id="@+id/attribution"
 		android:layout_width="0dp"
 		android:layout_height="wrap_content"
-		android:layout_margin="16dp"
 		android:padding="4dp"
 		android:textSize="12sp"
 		android:text="@string/map_attribution"


### PR DESCRIPTION
As a followup to #628  and #672, this PR adds the mapbox logo as also required by the  [attribution guidelines](https://docs.mapbox.com/help/how-mapbox-works/attribution/#mapbox-maps-sdk-for-android).

Also move the text attribution more to the lower-left edge.

![Transportr](https://user-images.githubusercontent.com/18088991/76710130-27e46b80-6705-11ea-8f76-2903bdd2f8a2.png)
