### PR TITLE
Improved geo intents

### DIFF
--- a/app/src/main/java/de/grobox/transportr/utils/IntentUtils.kt
+++ b/app/src/main/java/de/grobox/transportr/utils/IntentUtils.kt
@@ -97,11 +97,11 @@ object IntentUtils {
 
     @JvmStatic
     fun getWrapLocation(geoUri: String): WrapLocation? {
-        val pattern = Pattern.compile("^geo:(-?\\d{1,3}(\\.\\d{1,8})?),(-?\\d{1,3}(\\.\\d{1,8})?).*")
+        val pattern = Pattern.compile("^geo:(0,0\\?q=)?(-?\\d{1,3}(\\.\\d{1,8})?),(-?\\d{1,3}(\\.\\d{1,8})?).*")
         val matcher = pattern.matcher(geoUri)
         if (matcher.matches()) {
-            val lat: Double = matcher.group(1)!!.toDouble()
-            val lon: Double = matcher.group(3)!!.toDouble()
+            val lat: Double = matcher.group(2)!!.toDouble()
+            val lon: Double = matcher.group(4)!!.toDouble()
             return if (lat == 0.0 && lon == 0.0) null else WrapLocation(LatLng(lat, lon))
         }
         return null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="find_nearby_stations">Find Nearby Stations</string>
 	<string name="find_departures">Find Departures</string>
 	<string name="share_trip_via">Share Trip Via&#8230;</string>
+	<string name="show_location_in">Show Location In&#8230;</string>
 	<string name="more">More</string>
 
 	<!-- Shows a short(!) representation of how long you need to walk, e.g. "for 5 min" -->
@@ -149,6 +150,7 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="error_find_nearby_stations">Could not find nearby stations</string>
 	<string name="error_departures">Could not find any departures</string>
 	<string name="error_no_calendar">No calendar installed :(</string>
+	<string name="error_no_map">No external map installed :(</string>
 
 	<string name="trip_error_ambiguous">Could not find the location. Please try searching with different locations.</string>
 	<string name="trip_error_too_close">The \'from\' and the \'to\' location are too close together.</string>

--- a/app/src/test/java/de/grobox/transportr/utils/IntentUtilsTest.kt
+++ b/app/src/test/java/de/grobox/transportr/utils/IntentUtilsTest.kt
@@ -34,6 +34,7 @@ class MapViewModelTest {
         Assert.assertEquals(get(3.14159265, -3.14159265), IntentUtils.getWrapLocation("geo:3.14159265,-3.14159265?z=20"))
         Assert.assertEquals(get(-48.123, 126.0), IntentUtils.getWrapLocation("geo:-48.123,126(label)"))
         Assert.assertEquals(get(90.0, -126.0), IntentUtils.getWrapLocation("geo:90,-126?q=my+street+address"))
+        Assert.assertEquals(get(-48.123, 126.0), IntentUtils.getWrapLocation("geo:0,0?q=-48.123,126(label)"))
 
         Assert.assertNull(IntentUtils.getWrapLocation("geo:90"))
         Assert.assertNull(IntentUtils.getWrapLocation("geo:90,"))


### PR DESCRIPTION
- recognize `geo:0,0?q=lat,lon` intents as per [Android docs](https://developer.android.com/guide/components/intents-common\#ViewMap) and as used by Transportr itself
- exclude Transportr from "show on external map"

Fixes #698 