### PR TITLE
Fixed function definition to actually override onSaveInstanceState

### DIFF
--- a/app/src/main/java/de/grobox/transportr/networks/PickTransportNetworkActivity.kt
+++ b/app/src/main/java/de/grobox/transportr/networks/PickTransportNetworkActivity.kt
@@ -84,7 +84,7 @@ class PickTransportNetworkActivity : TransportrActivity(), ISelectionListener<II
         selectItem()
     }
 
-    override fun onSaveInstanceState(outState: Bundle?, outPersistentState: PersistableBundle) {
+    override fun onSaveInstanceState(outState: Bundle, outPersistentState: PersistableBundle) {
         val newState = adapter.saveInstanceState(outState)
         super.onSaveInstanceState(newState, outPersistentState)
     }


### PR DESCRIPTION
I am building with rather recent tools, guess that's why this bug showed up. Fixed it.
https://developer.android.com/reference/kotlin/android/app/Activity#onSaveInstanceState(android.os.Bundle,%20android.os.PersistableBundle)