### PR TITLE
Hide walking route unless it's the only one

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -17,7 +17,8 @@
     "brandsimon",
     "sideeffffect",
     "T0astBread",
-    "fgndev"
+    "fgndev",
+    "starsep"
   ],
   "label": "cla-signed ✔️",
   "message": "Thank you for your pull request and welcome to our community! We require contributors to sign our [Contributor License Agreement](https://github.com/grote/Transportr/blob/master/CLA.md), and we don't seem to have the user {{usersWithoutCLA}} on file. In order for your code to get reviewed and merged, please explicitly state that you accept the agreement. Alternatively, you can add a commit that adds yourself to https://github.com/grote/Transportr/blob/master/.clabot"

--- a/app/src/main/java/de/grobox/transportr/settings/SettingsManager.kt
+++ b/app/src/main/java/de/grobox/transportr/settings/SettingsManager.kt
@@ -135,6 +135,8 @@ class SettingsManager @Inject constructor(private val context: Context) {
         return settings.getBoolean(SHOW_WHEN_LOCKED, true)
     }
 
+    fun hideWalkingRoute(): Boolean = settings.getBoolean(HIDE_WALKING_ROUTE, false)
+
     companion object {
         private const val NETWORK_ID_1 = "NetworkId"
         private const val NETWORK_ID_2 = "NetworkId2"
@@ -147,6 +149,7 @@ class SettingsManager @Inject constructor(private val context: Context) {
         private const val OPTIMIZE = "pref_key_optimize"
         private const val LOCATION_ONBOARDING = "locationOnboarding"
         private const val TRIP_DETAIL_ONBOARDING = "tripDetailOnboarding"
+        private const val HIDE_WALKING_ROUTE = "pref_key_hide_walking_route"
     }
 
 }

--- a/app/src/main/java/de/grobox/transportr/trips/search/TripsRepository.kt
+++ b/app/src/main/java/de/grobox/transportr/trips/search/TripsRepository.kt
@@ -171,10 +171,17 @@ class TripsRepository(
             queryMoreState.value = getQueryMoreStateFromContext(queryTripsContext)
 
             val oldTrips = trips.value?.let { HashSet(it) } ?: HashSet()
-            oldTrips.addAll(queryTripsResult.trips)
+            oldTrips.addAll(filterOutWalkingRoute(newTrips = queryTripsResult.trips, oldTrips = oldTrips))
             trips.value = oldTrips
         }
     }
+
+    private fun filterOutWalkingRoute(newTrips: List<Trip>, oldTrips: Collection<Trip>): List<Trip> =
+        if (settingsManager.hideWalkingRoute() && (oldTrips.isNotEmpty() || newTrips.size > 1)) {
+            newTrips.filterNot { it.legs.size == 1 && it.legs.first() is Trip.Individual }
+        } else {
+            newTrips
+        }
 
     private fun getQueryMoreStateFromContext(context: QueryTripsContext?): QueryMoreState = context?.let {
         return if (it.canQueryEarlier() && it.canQueryLater()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,8 @@ and always knows where you are to not miss where to get off the bus.
 	<string name="pref_walk_speed_fast">Fast</string>
 	<string name="pref_show_when_locked_title">Show trip even when screen is locked</string>
 	<string name="pref_show_when_locked_summary">Show over lock screen</string>
+	<string name="pref_hide_walking_route_title">Hide walking route</string>
+	<string name="pref_hide_walking_route_summary">Walking route will be hidden unless it is the only one</string>
 
 	<string name="error">Error</string>
 	<string name="error_no_internet">Internet connection required. Please make sure your internet access is working.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -41,6 +41,13 @@
 			android:title="@string/pref_walk_speed"
 			app:iconSpaceReserved="false"/>
 
+		<CheckBoxPreference
+			android:defaultValue="false"
+			android:key="pref_key_hide_walking_route"
+			android:summary="@string/pref_hide_walking_route_summary"
+			android:title="@string/pref_hide_walking_route_title"
+			app:iconSpaceReserved="false"/>
+
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
# Rationale
I use the app mostly in the city I live in (Warsaw, Poland) - quite natural use case.
I know the city good enough that I don't really look for the public transport route if I would prefer to walk instead.
Therefore walking route is pretty much never a viable alternative - it's distracting and annoying to see it.

One possible solution would be to have "maximum walking time" as in #533 
I decided to implement something simpler which works for me: just hide the walking route if it's not the only one.

# Screenshots
Quite extreme case obviously - route between two subway stations, 11 minutes vs an hour. With the setting turned off and on.
![image](https://user-images.githubusercontent.com/2798728/119220944-31c5e380-baed-11eb-9409-773fc04a1867.png)
![image](https://user-images.githubusercontent.com/2798728/119220951-4013ff80-baed-11eb-9cb3-c1ff2bdc035f.png)

Settings screen
![image](https://user-images.githubusercontent.com/2798728/119220956-430ef000-baed-11eb-9ae5-f8f17012ab46.png)

PS I haven't created issue because I don't think it's "major work" but I can create one if needed.