### PR TITLE
Add Themed Icons

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -18,7 +18,8 @@
     "sideeffffect",
     "T0astBread",
     "fgndev",
-    "Altonss"
+    "Altonss",
+    "thgoebel"
   ],
   "label": "cla-signed ✔️",
   "message": "Thank you for your pull request and welcome to our community! We require contributors to sign our [Contributor License Agreement](https://github.com/grote/Transportr/blob/master/CLA.md), and we don't seem to have the user {{usersWithoutCLA}} on file. In order for your code to get reviewed and merged, please explicitly state that you accept the agreement. Alternatively, you can add a commit that adds yourself to https://github.com/grote/Transportr/blob/master/.clabot"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
 	<background android:drawable="@color/ic_launcher_background"/>
 	<foreground android:drawable="@drawable/ic_launcher_foreground"/>
+	<monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for Themed Icons (aka monochrome, aka Material You) to the app icon on the launcher.

See also: https://developer.android.com/develop/ui/views/launch/icon_design_adaptive

Tested only on vanilla Android 13 (LineageOS 20), but should (tm) introduce no regression on older Android versions.
Notably, it works on Android 13 (SDK 33) even while still targeting SDK 30.

Fixes #837.

### Screenshots

<img src=https://user-images.githubusercontent.com/33295590/231282408-8a7d6991-6955-41b2-b981-187b7b04deef.png width=35%> <img src=https://user-images.githubusercontent.com/33295590/231282416-94058b59-891d-4193-b601-c93a5cfdc218.png width=35%>

