### PR TITLE
Bump minSdk to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [16, 23, 29]
+        api-level: [21, 23, 29]
 
     steps:
       - uses: actions/checkout@v2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,5 +167,6 @@ dependencies {
 	androidTestImplementation('tools.fastlane:screengrab:1.1.0') {
 		exclude group: 'androidx.test.uiautomator' //requires minSDK >= 18
 	}
+	androidTestImplementation 'com.android.support:multidex-instrumentation:2.0.0'
 	kaptAndroidTestDebug "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 		versionName "2.1.4"
 
 		applicationId "de.grobox.liberario"
-		minSdkVersion 16
+		minSdkVersion 21
 		compileSdkVersion 31
 		targetSdkVersion 30
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,10 +38,8 @@ android {
 			resValue "string", "app_name", "Transportr Devel"
 			shrinkResources false
 			minifyEnabled false
-			multiDexEnabled true
 			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
 			testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt', 'proguard-test.txt'
-			multiDexKeepProguard file('proguard-multidex.txt')
 
 			lintOptions {
 				disable 'ProtectedPermissions'
@@ -167,6 +165,5 @@ dependencies {
 	androidTestImplementation('tools.fastlane:screengrab:1.1.0') {
 		exclude group: 'androidx.test.uiautomator' //requires minSDK >= 18
 	}
-	androidTestImplementation 'com.android.support:multidex-instrumentation:2.0.0'
 	kaptAndroidTestDebug "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/app/proguard-multidex.txt
+++ b/app/proguard-multidex.txt
@@ -1,3 +1,0 @@
-# Needed to make sure the instrumentation tests are available in the main DEX file for API < 20
-# source: https://github.com/android/testing-samples/issues/179#issuecomment-395020293
--keep @org.junit.runner.RunWith public class *

--- a/app/src/debug/java/de/grobox/transportr/TransportrDebugApplication.kt
+++ b/app/src/debug/java/de/grobox/transportr/TransportrDebugApplication.kt
@@ -19,11 +19,9 @@
 package de.grobox.transportr
 
 import android.content.Context
-import androidx.multidex.MultiDex
 
 class TransportrDebugApplication : TransportrApplication() {
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
-        MultiDex.install(this)
     }
 }

--- a/app/src/main/java/de/grobox/transportr/networks/RegionViewHolder.kt
+++ b/app/src/main/java/de/grobox/transportr/networks/RegionViewHolder.kt
@@ -77,12 +77,8 @@ internal class CountryViewHolder(v: View) : ExpandableRegionViewHolder<Country>(
 
     override fun bind(region: Country, expanded: Boolean) {
         super.bind(region, expanded)
-        if (Build.VERSION.SDK_INT >= 21) {
-            flag.text = region.flag
-            flag.visibility = VISIBLE
-        } else {
-            flag.visibility = GONE
-        }
+        flag.text = region.flag
+        flag.visibility = VISIBLE
     }
 }
 

--- a/app/src/main/java/de/grobox/transportr/ui/TransportrChangeLog.kt
+++ b/app/src/main/java/de/grobox/transportr/ui/TransportrChangeLog.kt
@@ -36,22 +36,12 @@ class TransportrChangeLog(context: Context, settingsManager: SettingsManager) : 
     companion object {
 
         private fun theme(dark: Boolean): String {
-            return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                if (dark) {
-                    // holo dark
-                    "body { color: #e7e3e7; font-size: 0.9em; background-color: #292829; } h1 { font-size: 1.3em; } ul { padding-left: 2em; }"
-                } else {
-                    // holo light
-                    "body { color: #212421; font-size: 0.9em; background-color: #f7f7f7; } h1 { font-size: 1.3em; } ul { padding-left: 2em; }"
-                }
+            return if (dark) {
+                // material dark
+                "body { color: #f3f3f3; font-size: 0.9em; background-color: #424242; } h1 { font-size: 1.3em; } ul { padding-left: 2em; }"
             } else {
-                if (dark) {
-                    // material dark
-                    "body { color: #f3f3f3; font-size: 0.9em; background-color: #424242; } h1 { font-size: 1.3em; } ul { padding-left: 2em; }"
-                } else {
-                    // material light
-                    "body { color: #202020; font-size: 0.9em; background-color: transparent; } h1 { font-size: 1.3em; } ul { padding-left: 2em; }"
-                }
+                // material light
+                "body { color: #202020; font-size: 0.9em; background-color: transparent; } h1 { font-size: 1.3em; } ul { padding-left: 2em; }"
             }
         }
 

--- a/app/witness.gradle
+++ b/app/witness.gradle
@@ -46,8 +46,6 @@ dependencyVerification {
         'androidx.lifecycle:lifecycle-viewmodel:2.3.1:lifecycle-viewmodel-2.3.1.aar:b6db4c274a12ff85a4747e1e6669c7e98aefa2571ace9d1f1a6fa6be417ce838',
         'androidx.loader:loader:1.0.0:loader-1.0.0.aar:11f735cb3b55c458d470bed9e25254375b518b4b1bad6926783a7026db0f5025',
         'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0:localbroadcastmanager-1.0.0.aar:e71c328ceef5c4a7d76f2d86df1b65d65fe2acf868b1a4efd84a3f34336186d8',
-        'androidx.multidex:multidex-instrumentation:2.0.0:multidex-instrumentation-2.0.0.aar:fb8115694b1731c23c1bbb628f5baaee37a8f3b50d69a7733b55278e101e1488',
-        'androidx.multidex:multidex:2.0.0:multidex-2.0.0.aar:c01700091072e0ff5d8ec2d00eac6b8f96ea18646080425e9ce3c6a7b5f66e33',
         'androidx.preference:preference:1.1.0:preference-1.1.0.aar:6cf1a099b03b3254041b04701841865b2708c0b546b9036c8b0dada0aa59de57',
         'androidx.print:print:1.0.0:print-1.0.0.aar:1d5c7f3135a1bba661fc373fd72e11eb0a4adbb3396787826dd8e4190d5d9edd',
         'androidx.recyclerview:recyclerview:1.0.0:recyclerview-1.0.0.aar:06956fb1ac014027ca9d2b40469a4b42aa61b4957bb11848e1ff352701ab4548',


### PR DESCRIPTION
This PR bumps minSdk to 21, and as such makes Transportr only compatible with Android devices running Android version 5.0 or above. This is done to simplify maintenance and fix bugs related to old versions.

This fixes:
- https://github.com/grote/Transportr/issues/721;
- https://github.com/grote/Transportr/issues/738;
- https://github.com/grote/Transportr/issues/471.