### PR TITLE
Prepare for release 2.1.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ apply from: 'witness.gradle'
 android {
 
 	defaultConfig {
-		versionCode 122
-		versionName "2.1.4"
+		versionCode 123
+		versionName "2.1.5"
 
 		applicationId "de.grobox.liberario"
 		minSdkVersion 21

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,7 @@ dependencies {
 		exclude module: 'failureaccess'
 		exclude group: 'com.google.j2objc'
 	}
-	implementation('com.gitlab.opentransitmap:public-transport-enabler:348d7340') {
+	implementation('com.gitlab.opentransitmap:public-transport-enabler:902b26d6') {
 		exclude group: 'com.google.guava' // included above
 		exclude group: 'org.json', module: 'json' // provided by Android
 		exclude group: 'net.sf.kxml', module: 'kxml2' // provided by Android

--- a/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
+++ b/app/src/main/java/de/grobox/transportr/networks/TransportNetworks.kt
@@ -161,13 +161,6 @@ private val networks = arrayOf(
                         factory = { VvoProvider(HttpUrl.parse("http://efaproxy.fahrinfo.uptrade.de/standard/")) }
                     ),
                     TransportNetwork(
-                        id = NetworkId.VMS,
-                        description = R.string.np_desc_vms,
-                        logo = R.drawable.network_vms_logo,
-                        status = BETA,
-                        factory = { VmsProvider(HttpUrl.parse("https://www.vms.de/Oeffi")) }
-                    ),
-                    TransportNetwork(
                         id = NetworkId.NASA,
                         name = R.string.np_name_nasa,
                         description = R.string.np_desc_nasa,
@@ -236,12 +229,6 @@ private val networks = arrayOf(
                         description = R.string.np_desc_vgs,
                         logo = R.drawable.network_vgs_logo,
                         factory = { VgsProvider("{\"type\":\"AID\",\"aid\":\"51XfsVqgbdA6oXzHrx75jhlocRg6Xe\"}", "HJtlubisvxiJxss".toByteArray(Charsets.UTF_8)) }
-                    ),
-                    TransportNetwork(
-                        id = NetworkId.VRS,
-                        description = R.string.np_desc_vrs,
-                        logo = R.drawable.network_vrs_logo,
-                        factory = { VrsProvider() }
                     ),
                     TransportNetwork(
                         id = NetworkId.VMT,
@@ -458,13 +445,6 @@ private val networks = arrayOf(
             ),
             Country(
                 R.string.np_region_poland, "🇵🇱", networks = listOf(
-                    TransportNetwork(
-                        id = NetworkId.PL,
-                        name = R.string.np_name_pl,
-                        description = R.string.np_desc_pl,
-                        logo = R.drawable.network_pl_logo,
-                        factory = { PlProvider() }
-                    ),
                     TransportNetwork(
                         id = NetworkId.PLNAVITIA,
                         name = R.string.np_name_pl_navitia,

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,6 +3,13 @@
     tools:ignore="UnusedResources">
 
     <release
+        version="2.1.5"
+        versioncode="123">
+        <change>Fixed bug where calendar and map apps are not found</change>
+        <change>Updated PTE data library - removed VMS, VRS, and PL</change>
+    </release>
+
+    <release
         version="2.1.4"
         versioncode="122">
         <change>Update PTE data library, fixes issues with Berlin BVG, removes SBB</change>

--- a/app/witness.gradle
+++ b/app/witness.gradle
@@ -110,7 +110,7 @@ dependencyVerification {
         'com.android:zipflinger:4.1.3:zipflinger-4.1.3.jar:48569896c0497268308a8014c66eb0f2bace2b9e2fc9390f3012823fb86387d5',
         'com.github.omadahealth:swipy:1.2.3:swipy-1.2.3.aar:63bff6e181742e3e243c29b595062ca65b4274bf7033c65460924f64f65c01e0',
         'com.github.tony19:logback-android:1.1.1-12:logback-android-1.1.1-12.aar:3102228f0e408e3c003b34e96a604e9b9f59d314dcf8f03aa78d9d3648198932',
-        'com.gitlab.opentransitmap:public-transport-enabler:348d7340:public-transport-enabler-348d7340.jar:d47adec13759f3d348a5201df6fc5f3ace2c730d2f06ea4fd396089bcf8c57d4',
+        'com.gitlab.opentransitmap:public-transport-enabler:902b26d6:public-transport-enabler-902b26d6.jar:a8b3e5ddae24d27e7713fc68dfa84da2288e48fbe7ccc90cf6ce40ef40b4a6bf',
         'com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.0:accessibility-test-framework-2.0.jar:cdf16ef8f5b8023d003ce3cc1b0d51bda737762e2dab2fedf43d1c4292353f7f',
         'com.google.android.material:material:1.0.0:material-1.0.0.aar:7680e381a3c03798d999b2e441caadd8a56a0a808e108024a67af9fe26c11adc',
         'com.google.android.material:material:1.3.0:material-1.3.0.aar:cbf1e7d69fc236cdadcbd1ec5f6c0a1a41aca6ad1ef7f8481058956270ab1f0a',
@@ -211,6 +211,7 @@ dependencyVerification {
         'org.ow2.asm:asm-util:7.0:asm-util-7.0.jar:75fbbca440ef463f41c2b0ab1a80abe67e910ac486da60a7863cbcb5bae7e145',
         'org.ow2.asm:asm:7.0:asm-7.0.jar:b88ef66468b3c978ad0c97fd6e90979e56155b4ac69089ba7a44e9aa7ffe9acf',
         'org.slf4j:slf4j-api:1.7.32:slf4j-api-1.7.32.jar:3624f8474c1af46d75f98bc097d7864a323c81b3808aa43689a6e1c601c027be',
+        'org.slf4j:slf4j-api:2.0.7:slf4j-api-2.0.7.jar:5d6298b93a1905c32cda6478808ac14c2d4a47e91535e53c41f7feeb85d946f4',
         'tools.fastlane:screengrab:1.1.0:screengrab-1.1.0.aar:03ce3868ee8a0082d14e7a1de0999f91531c0cc794392688beb08ee9bc4495fd',
         'uk.co.samuelwall:material-tap-target-prompt:2.14.0:material-tap-target-prompt-2.14.0.aar:12ab447ba97019adbecb20e048921ca30ed7a9f72a37b83f39a4333bd759b518',
     ]

--- a/fastlane/metadata/android/en-US/changelogs/123.txt
+++ b/fastlane/metadata/android/en-US/changelogs/123.txt
@@ -1,0 +1,2 @@
+* Fixed bug where calendar and map apps are not found
+* Updated PTE data library - removed VMS, VRS, and PL


### PR DESCRIPTION
This PR prepares the next release `2.1.1`.

* [x] update PTE to the latest commit at [opentransitmap](https://gitlab.com/opentransitmap/public-transport-enabler/-/commits/master) and run `./update-dependency-pinning.sh`
* [x] test the app (automatically using AndroidTest as well as manually), paying special attention to changes since the last release
  * manually tested for London and Paris
  * `searchLocationShowDeparturesTest` has been flaky
  * navitia returns `The region XX-XX doesn't exists"` a lot.
* [x] fix any bugs if necessary
* [] update translations from [Transifex](https://www.transifex.com/) using `tx pull --mode=developer -a` in the root folder (you need proper permissions to do that)
  * I don't have the permission but assumed no new strings?
* [x] ~~add newly supported languages to the two arrays in [`app/src/main/res/values/arrays.xml`](https://github.com/grote/Transportr/blob/master/app/src/main/res/values/arrays.xml#L16)~~
* [x] revise the commits to `master` since the last release and add interesting changes (as well as new languages) to the changelog at [`app/src/main/res/xml/changelog_master.xml`](https://github.com/grote/Transportr/blob/master/app/src/main/res/xml/changelog_master.xml), then run `python3 ./fastlane/generate_changelog.py`
* [x] bump the [`versionCode`](https://github.com/grote/Transportr/blob/master/app/build.gradle#L14) and [`versionName`](https://github.com/grote/Transportr/blob/master/app/build.gradle#L15) in `app/build.gradle`
* [] ~~add a last commit updating all dependencies right after the release~~
  * I will follow up on this.
