### PR TITLE
Update Github actions

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -20,7 +20,8 @@
     "fgndev",
     "Altonss",
     "thgoebel",
-    "pt2121"
+    "pt2121",
+    "Jean-BaptisteC"
   ],
   "label": "cla-signed ✔️",
   "message": "Thank you for your pull request and welcome to our community! We require contributors to sign our [Contributor License Agreement](https://github.com/grote/Transportr/blob/master/CLA.md), and we don't seem to have the user {{usersWithoutCLA}} on file. In order for your code to get reviewed and merged, please explicitly state that you accept the agreement. Alternatively, you can add a commit that adds yourself to https://github.com/grote/Transportr/blob/master/.clabot"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
         api-level: [21, 29, 31]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: 8


### PR DESCRIPTION
Some older actions used node12 and this version is deprecated -> more information here https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/