### PR TITLE
Proguard: keep strings for about > libraries

### DIFF
--- a/app/proguard-rules.txt
+++ b/app/proguard-rules.txt
@@ -51,3 +51,7 @@
 -keep class de.grobox.transportr.**
 -dontwarn de.grobox.transportr.data.**
 -dontnote de.grobox.transportr.ui.**
+
+-keepclasseswithmembers class **.R$* {
+    public static final int define_*;
+}


### PR DESCRIPTION
following instructions from https://github.com/mikepenz/AboutLibraries/tree/v6.2.0#proguard

fixes #793 