### PR TITLE
Release 2.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ apply from: 'witness.gradle'
 android {
 
 	defaultConfig {
-		versionCode 124
-		versionName "2.2.0"
+		versionCode 125
+		versionName "2.2.1"
 
 		applicationId "de.grobox.liberario"
 		minSdkVersion 21

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,6 +3,13 @@
     tools:ignore="UnusedResources">
 
     <release
+        version="2.2.1"
+        versioncode="125">
+        <change>Fix app crash at startup when no network-backed location provider was available (thanks Altonss!)</change>
+        <change>Make sure all parts of the app follow theme settings consistently</change>
+    </release>
+
+    <release
         version="2.2.0"
         versioncode="124">
         <change>Switch map library to MapLibre - finally bringing Transportr back to F-Droid!</change>

--- a/fastlane/metadata/android/en-US/changelogs/125.txt
+++ b/fastlane/metadata/android/en-US/changelogs/125.txt
@@ -1,0 +1,2 @@
+* Fix app crash at startup when no network-backed location provider was available (thanks Altonss!)
+* Make sure all parts of the app follow theme settings consistently


### PR DESCRIPTION
Here are the steps to follow when preparing a new release (some custom tasks added for this release). Please check the following boxes with an `x` when done:

* ~~update PTE to the latest commit at [opentransitmap](https://gitlab.com/opentransitmap/public-transport-enabler/-/commits/master) and run `./update-dependency-pinning.sh`~~
* [x] test the app (automatically using AndroidTest as well as manually), paying special attention to changes since the last release
* [ ] ~~fix any bugs if necessary~~
* ~~update translations from [Transifex](https://www.transifex.com/) using `tx pull --mode=developer -a` in the root folder (you need proper permissions to do that)~~
* ~~add newly supported languages to the two arrays in [`app/src/main/res/values/arrays.xml`](https://github.com/grote/Transportr/blob/master/app/src/main/res/values/arrays.xml#L16)~~
* [x] revise the commits to `master` since the last release and add interesting changes (as well as new languages) to the changelog at [`app/src/main/res/xml/changelog_master.xml`](https://github.com/grote/Transportr/blob/master/app/src/main/res/xml/changelog_master.xml), then run `python3 ./fastlane/generate_changelog.py`
* [x] bump the [`versionCode`](https://github.com/grote/Transportr/blob/master/app/build.gradle#L14) and [`versionName`](https://github.com/grote/Transportr/blob/master/app/build.gradle#L15) in `app/build.gradle`
* [ ] file another PR updating all dependencies which should be merged *after* the successful release

This is just a fixup release for 2.2.0 mainly fixing #911 and raising the target API level to 33 to enable distribution via Google Play.
~~Draft since manual release tests are still outstanding.~~